### PR TITLE
Performance: Enable lazy loading and split chunks

### DIFF
--- a/client/App.jsx
+++ b/client/App.jsx
@@ -1,27 +1,31 @@
-import React from 'react'
+import React, { lazy, Suspense } from 'react'
 import { Route, Switch, BrowserRouter as Router } from 'react-router-dom'
 
 import '~/public/assets/styles/index.css'
 
 import Navbar from '~/client/components/Navbar'
-import About from '~/client/components/About'
-import Home from '~/client/components/Home'
-import Work from '~/client/components/Work'
-import Articles from '~/client/components/Articles'
-import Contact from '~/client/components/Contact'
 import Footer from '~/client/components/Footer'
+import Loading from '~/client/components/Loading'
+
+const About = lazy(() => import('~/client/components/About'))
+const Home = lazy(() => import('~/client/components/Home'))
+const Work = lazy(() => import('~/client/components/Work'))
+const Articles = lazy(() => import('~/client/components/Articles'))
+const Contact = lazy(() => import('~/client/components/Contact'))
 
 export default () => (
   <Router>
     <div>
       <Navbar />
-      <Switch>
-        <Route exact path='/' component={Home} />
-        <Route exact path='/about' component={About} />
-        <Route exact path='/work' component={Work} />
-        <Route exact path='/articles' component={Articles} />
-        <Route exact path='/contact' component={Contact} />
-      </Switch>
+      <Suspense fallback={<Loading />}>
+        <Switch>
+          <Route exact path='/' component={Home} />
+          <Route exact path='/about' component={About} />
+          <Route exact path='/work' component={Work} />
+          <Route exact path='/articles' component={Articles} />
+          <Route exact path='/contact' component={Contact} />
+        </Switch>
+      </Suspense>
       <Footer />
     </div>
   </Router>

--- a/client/components/Contact.js
+++ b/client/components/Contact.js
@@ -1,5 +1,6 @@
-import React from 'react'
-import Form from './Form'
+import React, { lazy, Suspense } from 'react'
+import Loading from './Loading'
+const Form = lazy(() => import('./Form'))
 
 import windowTrick from '~/client/window'
 
@@ -13,10 +14,12 @@ export default () => {
 
   return (
     <Contact>
-      <H2>Let's Work Together!</H2>
+      <H2>Let&apos;s Work Together!</H2>
       <ContactForm>
         <span>
-          <Form />
+          <Suspense fallback={<Loading />}>
+            <Form />
+          </Suspense>
           <Disclaimer>{reCaptchaMessage}</Disclaimer>
         </span>
       </ContactForm>

--- a/client/components/Loading.jsx
+++ b/client/components/Loading.jsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+import { StyledLoading } from '~/client/styles/loading'
+
+export default () => <StyledLoading>Loading...</StyledLoading>

--- a/client/components/Work.js
+++ b/client/components/Work.js
@@ -1,7 +1,9 @@
-import React from 'react'
+import React, { lazy, Suspense } from 'react'
 
 import Link from './Link'
-import Expand from './Expand'
+import Loading from './Loading'
+const Expand = lazy(() => import('./Expand'))
+
 import { ResumeButton } from '~/client/styles/button'
 
 import windowTrick from '~/client/window'
@@ -14,7 +16,9 @@ export default () => {
       <Link href='/assets/Eleni-Arvanitis-Resume.pdf'>
         <ResumeButton>View Resume</ResumeButton>
       </Link>
-      <Expand />
+      <Suspense fallback={<Loading />}>
+        <Expand />
+      </Suspense>
     </>
   )
 }

--- a/client/styles/loading.js
+++ b/client/styles/loading.js
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+
+export const StyledLoading = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  font-size: 15pt;
+`

--- a/public/index.html
+++ b/public/index.html
@@ -42,7 +42,9 @@
   <body>
     <div id="main" role="main">
     </div>
+    <script async defer src="vendors.bundle.js"></script>
     <script async defer src="main.bundle.js"></script>
+    <script async defer src="runtime.bundle.js"></script>
     <script>
       if ('serviceWorker' in navigator) {
         navigator.serviceWorker

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,8 @@
 const webpack = require('webpack')
+const { GenerateSW } = require('workbox-webpack-plugin')
+
 const babel = require('./babel.config')
 const { isHot, isProd } = require('./env.config')
-const { GenerateSW } = require('workbox-webpack-plugin')
 
 const entries = (env, entry) =>
   isHot(env) ? ['react-hot-loader/patch', entry] : entry
@@ -56,9 +57,19 @@ const config = env => ({
   optimization: {
     mergeDuplicateChunks: true,
     removeEmptyChunks: true,
-    // splitChunks: {
-    //   chunks: 'all',
-    // },
+    runtimeChunk: 'single',
+    splitChunks: {
+      maxInitialRequests: 20, // for HTTP2
+      maxAsyncRequests: 20, // for HTTP2
+      minSize: 40,
+      cacheGroups: {
+        vendors: {
+          test: /[\\/]node_modules[\\/]/,
+          name: 'vendors',
+          chunks: 'all',
+        },
+      },
+    },
   },
   plugins: plugins(env),
 })
@@ -81,6 +92,7 @@ function devServer(env) {
   if (isProd(env)) return
   const { FIREBASE_SERVE_URL } = env
   return {
+    compress: true,
     disableHostCheck: true,
     hot: true,
     proxy: FIREBASE_SERVE_URL && {


### PR DESCRIPTION
### Proposed Changes

- Import `lazy` and `Suspense` where possible for lazy loading and fallbacks
- Create `Loading` and respective `StyledLoading` components for fallback when lazy loading
- Use `&apos;` on `/contact`
  - "Let's..." -> "Let&apos;s"
  - `eslint` fix
- Use split chunks within webpack