### PR TITLE
Fix: Move hidden recaptcha badge to left

### DIFF
--- a/public/assets/styles/index.css
+++ b/public/assets/styles/index.css
@@ -25,6 +25,7 @@ body {
 
 .grecaptcha-badge {
   opacity: 0;
+  left: 0;
 }
 
 


### PR DESCRIPTION
I'm hiding the recaptcha badge in favor of a disclaimer, as per Google's recommendation. However, now that I've implemented colors upon hover for contact links, I've realized that this breaks the contact links around the perimeter of the badge. Then, since there's no reason to re-render those links, when one moves to different routes, the breakage persists.

Moving the badge to the left fixes this problem.