### PR TITLE
Fix: Resolve ghost form issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For information on my journey to becoming a Software Engineer, check out my
 
 ### Frontend
 
-The frontend starts in [`main.js`]. The root of the react app is in [`App.jsx`].
+The frontend starts in [`main.js`]. The root of the React app is in [`App.jsx`].
 
 #### a word about ~
 
@@ -44,13 +44,8 @@ the root and all styles. I now have a :100:.
 
 I have implemented a form on `/contact` that sends submissions directly to my
 email using `emailjs`. The Google ReCAPTCHA library helps verify a human's
-(online) humanity so as to prevent bots from submitting the form. It uses
-ReCAPTCHA v3, which is invisible.
-
-**⚠️ Note:** This is currently not working in tandem with `emailjs`, as
-`emailjs` only supports v2. The email will send a message, but no name or email
-values, rendering this entire functionality useless until `emailjs` updates to
-allow the user to choose between ReCAPTCHA versions.
+(online) humanity to prevent bots from submitting the form. It uses ReCAPTCHA
+v3, which is invisible.
 
 ### Testing
 
@@ -66,6 +61,6 @@ commented out in my various components.
 [emailjs]: https://www.emailjs.com/
 [webpack]: https://webpack.js.org/
 [babel]: https://babeljs.io/
-[`main.js`]: ./main.js
+[`main.js`]: main.js
 [`app.jsx`]: client/App.jsx
 [`webpack.config.js`]: webpack.config.js

--- a/client/components/Form.js
+++ b/client/components/Form.js
@@ -33,12 +33,13 @@ const getInputs = ({ name, email, message }) => [
 
 export default () => {
   const { addToast } = useToasts()
-  const [state, setState] = useState({
+  const initialState = {
     name: '',
     email: '',
     message: '',
     token: '',
-  })
+  }
+  const [state, setState] = useState(initialState)
 
   const verifyHumanity = token => setState({ ...state, token })
   useEffect(token => loadReCaptcha(siteKey, verifyHumanity(token)), [])
@@ -54,10 +55,19 @@ export default () => {
   const sendEmail = evt => {
     evt.preventDefault()
 
+    const emailTemplate = {
+      to_name: 'Eleni',
+      from_name: state.name,
+      message: state.message,
+      reply_to: state.email,
+    }
+
     emailjs
-      .sendForm(serviceId, templateId, evt.target, userId)
+      .send(serviceId, templateId, emailTemplate)
       .then(() => addToast('Email sent!', { appearance: 'success' }))
       .catch(err => addToast(err.text, { appearance: 'error' }))
+
+    setState(initialState)
   }
 
   const inputs = getInputs(state)

--- a/client/components/Form.js
+++ b/client/components/Form.js
@@ -66,8 +66,7 @@ export default () => {
       .send(serviceId, templateId, emailTemplate)
       .then(() => addToast('Email sent!', { appearance: 'success' }))
       .catch(err => addToast(err.text, { appearance: 'error' }))
-
-    setState(initialState)
+      .finally(() => setState(initialState))
   }
 
   const inputs = getInputs(state)


### PR DESCRIPTION
### Proposed Changes

- Use `emailjs.send` instead of `emailjs.sendForm`
  - This allowed direct use of `state` in order to pass relevant information to my email whenever someone uses my form
  - Note: Before, this would only send the message without a name or reply email :(
- Reset state after a form has been submitted
- Minor tweaks to `README`