### PR TITLE
Refactor: Alter import scheme for fortawesome

### DIFF
--- a/client/components/Footer.js
+++ b/client/components/Footer.js
@@ -1,10 +1,8 @@
 import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faGithubAlt } from '@fortawesome/free-brands-svg-icons/faGitHubAlt'
-import { faLinkedin } from '@fortawesome/free-brands-svg-icons/faLinkedin'
-import { faMediumM } from '@fortawesome/free-brands-svg-icons/faMediumM'
-import { faTwitter } from '@fortawesome/free-brands-svg-icons/faTwitter'
-import { faEnvelope } from '@fortawesome/free-solid-svg-icons/faEnvelope'
+import { faGithubAlt, faLinkedin } from '@fortawesome/free-brands-svg-icons'
+import { faMediumM, faTwitter } from '@fortawesome/free-brands-svg-icons'
+import { faEnvelope } from '@fortawesome/free-solid-svg-icons'
 
 import { Footer, Copyright, Icon } from '~/client/styles/footer'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "@emailjs/browser": "^3.4.0",
-        "@fortawesome/fontawesome-svg-core": "^6.1.0",
         "@fortawesome/free-brands-svg-icons": "^6.0.0",
         "@fortawesome/free-solid-svg-icons": "^6.0.0",
         "@fortawesome/react-fontawesome": "^0.1.17",
@@ -2564,6 +2563,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.0.tgz",
       "integrity": "sha512-racj+/EDnMZN0jcuHePOa+9kdHHOCpCAbBvVRnEi4G4DA5SWQiT/uXJ8WcfVEbLN51vPJjhukP4o+zH0cfYplg==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.1.0"
       },
@@ -29829,6 +29829,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.0.tgz",
       "integrity": "sha512-racj+/EDnMZN0jcuHePOa+9kdHHOCpCAbBvVRnEi4G4DA5SWQiT/uXJ8WcfVEbLN51vPJjhukP4o+zH0cfYplg==",
+      "peer": true,
       "requires": {
         "@fortawesome/fontawesome-common-types": "6.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
   },
   "dependencies": {
     "@emailjs/browser": "^3.4.0",
-    "@fortawesome/fontawesome-svg-core": "^6.1.0",
     "@fortawesome/free-brands-svg-icons": "^6.0.0",
     "@fortawesome/free-solid-svg-icons": "^6.0.0",
     "@fortawesome/react-fontawesome": "^0.1.17",


### PR DESCRIPTION
- Uninstall @fortawesome/fontawesome-svg-core ... likely at some point this was no longer required to import directly
- Remove tree shaking capabilities for fontawesome icons since by default that is now included