### PR TITLE
Fix: Replace react-recaptcha-v3 with updated react-google-recaptcha-v3

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,9 @@
 const { isHot } = require('./env.config')
 
-const plugins = ['babel-plugin-styled-components']
+const plugins = [
+  '@babel/plugin-transform-runtime',
+  'babel-plugin-styled-components',
+]
 
 const babel = (module.exports = {
   presets: [

--- a/client/components/Button.jsx
+++ b/client/components/Button.jsx
@@ -5,7 +5,11 @@ import Link from '~/client/components/Link'
 import { Button, ProjectLinkButton, SubmitButton } from '~/client/styles/button'
 
 export default ({ text }) => <Button>{text}</Button>
-export const Submit = () => <SubmitButton type='submit'>Submit</SubmitButton>
+export const Submit = props => (
+  <SubmitButton type='submit' {...props}>
+    Submit
+  </SubmitButton>
+)
 
 const determineProjectButtonLink = ({ code, youtube, demo }) =>
   code ? code : youtube ? youtube : demo

--- a/main.js
+++ b/main.js
@@ -1,16 +1,21 @@
+/* eslint no-undef: 0 */
+
 import React from 'react'
 import { render } from 'react-dom'
 import { AppContainer } from 'react-hot-loader'
 import { ToastProvider } from 'react-toast-notifications'
+import { GoogleReCaptchaProvider } from 'react-google-recaptcha-v3'
 
 import App from '~/client/App'
 
 function main() {
   render(
     <AppContainer>
-      <ToastProvider autoDismissTimeout={3000} autoDismiss={true}>
-        <App />
-      </ToastProvider>
+      <GoogleReCaptchaProvider reCaptchaKey={process.env.RECAPTCHA_SITE_KEY}>
+        <ToastProvider autoDismissTimeout={3000} autoDismiss={true}>
+          <App />
+        </ToastProvider>
+      </GoogleReCaptchaProvider>
     </AppContainer>,
     document.getElementById('main')
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-firebase-hooks": "^5.0.2",
-        "react-recaptcha-v3": "^2.0.1",
+        "react-google-recaptcha-v3": "^1.9.7",
         "react-router-dom": "^6.2.1",
         "react-text-transition": "^1.3.0",
         "react-toast-notifications": "^2.5.1",
@@ -25,6 +25,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.17.5",
+        "@babel/plugin-transform-runtime": "^7.17.0",
         "@babel/preset-env": "^7.16.11",
         "@babel/preset-react": "^7.16.7",
         "@babel/runtime": "^7.17.2",
@@ -1518,6 +1519,26 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.16.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.17.0.tgz",
+      "integrity": "sha512-fr7zPWnKXNc1xoHfrIU9mN/4XKX4VLZ45Q+oMhfsYIaHvg7mHgmhfOy/ckRWqDK7XF3QDigRpkh5DKq6+clE8A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "babel-plugin-polyfill-corejs2": "^0.3.0",
+        "babel-plugin-polyfill-corejs3": "^0.5.0",
+        "babel-plugin-polyfill-regenerator": "^0.3.0",
+        "semver": "^6.3.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -24806,6 +24827,18 @@
         "react": ">= 16.8.0"
       }
     },
+    "node_modules/react-google-recaptcha-v3": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/react-google-recaptcha-v3/-/react-google-recaptcha-v3-1.9.7.tgz",
+      "integrity": "sha512-LgHTuPUE86jGOtmMYMUWEYux8n7M2ZNj5GHct//DlXWZGyLIgFfLbvxA3UlgrG+tSu2pgw2mqXtYdPxaldqhWQ==",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0",
+        "react-dom": "^17.0"
+      }
+    },
     "node_modules/react-hot-loader": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.13.0.tgz",
@@ -24854,15 +24887,6 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "dev": true
-    },
-    "node_modules/react-recaptcha-v3": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/react-recaptcha-v3/-/react-recaptcha-v3-2.0.1.tgz",
-      "integrity": "sha512-ZQ+auotgu+E/6YAbPqk53sf9xgcp8TFvVVfL4bVR7PXj98nQmdaONugdLJEA7g1iTZ4yQqC4mZbcVUGZmwb25Q==",
-      "peerDependencies": {
-        "prop-types": "^15.6.2",
-        "react": "^15.6.2 || ^16.x"
-      }
     },
     "node_modules/react-router": {
       "version": "6.2.2",
@@ -28891,6 +28915,20 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.16.7"
+      }
+    },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.17.0.tgz",
+      "integrity": "sha512-fr7zPWnKXNc1xoHfrIU9mN/4XKX4VLZ45Q+oMhfsYIaHvg7mHgmhfOy/ckRWqDK7XF3QDigRpkh5DKq6+clE8A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "babel-plugin-polyfill-corejs2": "^0.3.0",
+        "babel-plugin-polyfill-corejs3": "^0.5.0",
+        "babel-plugin-polyfill-regenerator": "^0.3.0",
+        "semver": "^6.3.0"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
@@ -47481,6 +47519,14 @@
       "integrity": "sha512-0+V2XwInZJNjW8B2cm+U21Hlv4xnp/1tJqIoDg2rjyWzKTQ9VoLPQ9PAt+fMqPumjLz5uCIREY7YqGSSjc439Q==",
       "requires": {}
     },
+    "react-google-recaptcha-v3": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/react-google-recaptcha-v3/-/react-google-recaptcha-v3-1.9.7.tgz",
+      "integrity": "sha512-LgHTuPUE86jGOtmMYMUWEYux8n7M2ZNj5GHct//DlXWZGyLIgFfLbvxA3UlgrG+tSu2pgw2mqXtYdPxaldqhWQ==",
+      "requires": {
+        "hoist-non-react-statics": "^3.3.2"
+      }
+    },
     "react-hot-loader": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.13.0.tgz",
@@ -47515,12 +47561,6 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "dev": true
-    },
-    "react-recaptcha-v3": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/react-recaptcha-v3/-/react-recaptcha-v3-2.0.1.tgz",
-      "integrity": "sha512-ZQ+auotgu+E/6YAbPqk53sf9xgcp8TFvVVfL4bVR7PXj98nQmdaONugdLJEA7g1iTZ4yQqC4mZbcVUGZmwb25Q==",
-      "requires": {}
     },
     "react-router": {
       "version": "6.2.2",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "license": "ISC",
   "devDependencies": {
     "@babel/core": "^7.17.5",
+    "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-react": "^7.16.7",
     "@babel/runtime": "^7.17.2",
@@ -82,7 +83,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-firebase-hooks": "^5.0.2",
-    "react-recaptcha-v3": "^2.0.1",
+    "react-google-recaptcha-v3": "^1.9.7",
     "react-router-dom": "^6.2.1",
     "react-text-transition": "^1.3.0",
     "react-toast-notifications": "^2.5.1",


### PR DESCRIPTION
- Install `@babel/plugin-transform-runtime` to use `async...await` functionality in reCAPTCHA verification
- Allow props for `submit` buttons in order to run reCAPTCHA verification on the submit button itself
- Use `react-google-recaptcha-v3` as recommended in the docs
  - Do this for two reasons:
     1. It's been updated more recently and has React v17 as a dependency
     2. It hopefully will resolve issues with reCAPTCHA keys via `process.env`