### PR TITLE
chore(update): refactor firebase code to use modular sdk rather than compat

### DIFF
--- a/db/firebase.js
+++ b/db/firebase.js
@@ -1,9 +1,9 @@
-/* eslint no-undef: 0 */
+/* eslint no-undef: 0 no-unused-vars: 0 */
 
-import firebase from 'firebase/compat/app'
+import { initializeApp } from 'firebase/app'
 import { getDatabase } from 'firebase/database'
 
-firebase.initializeApp({
+const fire = initializeApp({
   apiKey: process.env.FIREBASE_API_KEY,
   databaseURL: 'https://elenicodes.firebaseio.com',
   projectId: 'elenicodes',

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@fortawesome/free-brands-svg-icons": "^6.1.0",
         "@fortawesome/free-solid-svg-icons": "^6.1.0",
         "@fortawesome/react-fontawesome": "^0.1.18",
-        "firebase": "^9.6.6",
+        "firebase": "^9.6.8",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-firebase-hooks": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@fortawesome/free-brands-svg-icons": "^6.1.0",
     "@fortawesome/free-solid-svg-icons": "^6.1.0",
     "@fortawesome/react-fontawesome": "^0.1.18",
-    "firebase": "^9.6.6",
+    "firebase": "^9.6.8",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-firebase-hooks": "^5.0.2",


### PR DESCRIPTION
Follows firebase docs to use modular version of firebase SDK v9 instead of v9 compat to reduce bundle size. I didn't find too much of a difference, but it's a start.