### PR TITLE
[fix] update to react-refresh so HMR can work again

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,7 +2,7 @@ const plugins = [
   '@babel/plugin-transform-runtime',
   'babel-plugin-styled-components',
   'macros',
-  'react-hot-loader/babel',
+  process.env.NODE_ENV === 'development' && 'react-refresh/babel',
 ]
 
 const babel = {
@@ -10,7 +10,7 @@ const babel = {
     ['@babel/preset-env', { modules: false, forceAllTransforms: true }],
     '@babel/preset-react',
   ],
-  plugins,
+  plugins: plugins.filter(Boolean),
 }
 
 export default babel

--- a/client/App.jsx
+++ b/client/App.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { hot } from 'react-hot-loader/root'
 import { Route, Routes, BrowserRouter as Router } from 'react-router-dom'
 
 import '~/public/assets/styles/index.css'
@@ -28,4 +27,4 @@ const App = () => (
   </Router>
 )
 
-export default hot(App)
+export default App

--- a/client/components/About.js
+++ b/client/components/About.js
@@ -2,10 +2,10 @@ import React from 'react'
 import { NavLink } from 'react-router-dom'
 
 import Button from '~/client/components/Button'
-import { About, AboutHeader, AboutText } from '~/client/styles/about'
+import { StyledAbout, AboutHeader, AboutText } from '~/client/styles/about'
 
-export default () => (
-  <About>
+const About = () => (
+  <StyledAbout>
     <AboutHeader>Creating useful and engaging software</AboutHeader>
     <AboutText>
       <p>
@@ -34,5 +34,7 @@ export default () => (
     <NavLink to='/work'>
       <Button text='See my work' />
     </NavLink>
-  </About>
+  </StyledAbout>
 )
+
+export default About

--- a/client/components/Articles.js
+++ b/client/components/Articles.js
@@ -14,7 +14,7 @@ import {
 
 import db from '~/db/firebase'
 
-export default () => {
+const Articles = () => {
   const [articles, setArticles] = useState([])
   useEffect(
     () =>
@@ -38,3 +38,5 @@ export default () => {
     </Article>
   ))
 }
+
+export default Articles

--- a/client/components/Button.jsx
+++ b/client/components/Button.jsx
@@ -2,9 +2,13 @@ import React from 'react'
 
 import Link from '~/client/components/Link'
 
-import { Button, ProjectLinkButton, SubmitButton } from '~/client/styles/button'
+import {
+  StyledButton,
+  ProjectLinkButton,
+  SubmitButton,
+} from '~/client/styles/button'
 
-export default ({ text }) => <Button>{text}</Button>
+const Button = ({ text }) => <StyledButton>{text}</StyledButton>
 export const Submit = props => (
   <SubmitButton type='submit' {...props}>
     Submit
@@ -23,3 +27,5 @@ export const ProjectLink = ({ link }) => (
     <ProjectLinkButton>{determineProjectButtonText(link)}</ProjectLinkButton>
   </Link>
 )
+
+export default Button

--- a/client/components/Contact.js
+++ b/client/components/Contact.js
@@ -3,13 +3,18 @@ import Form from '~/client/components/Form'
 
 import windowTrick from '~/client/window'
 
-import { Contact, ContactForm, H2, Disclaimer } from '~/client/styles/contact'
+import {
+  StyledContact,
+  ContactForm,
+  H2,
+  Disclaimer,
+} from '~/client/styles/contact'
 
-export default () => {
+const Contact = () => {
   windowTrick()
 
   return (
-    <Contact>
+    <StyledContact>
       <H2>Let&apos;s Work Together!</H2>
       <ContactForm>
         <span>
@@ -20,6 +25,8 @@ export default () => {
           </Disclaimer>
         </span>
       </ContactForm>
-    </Contact>
+    </StyledContact>
   )
 }
+
+export default Contact

--- a/client/components/Expand.js
+++ b/client/components/Expand.js
@@ -13,7 +13,7 @@ import {
 
 import db from '~/db/firebase'
 
-export default () => {
+const Expand = () => {
   const [isHidden, setIsHidden] = useState(true)
   const [selectedProject, setSelectedProject] = useState('')
   const [projects, setProjects] = useState([])
@@ -73,3 +73,5 @@ export default () => {
     )
   })
 }
+
+export default Expand

--- a/client/components/Footer.js
+++ b/client/components/Footer.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { brands, solid } from '@fortawesome/fontawesome-svg-core/import.macro'
 
-import { Footer, Copyright, Icon } from '~/client/styles/footer'
+import { StyledFooter, Copyright, Icon } from '~/client/styles/footer'
 
 const socialLinks = [
   ['https://github.com/datgreekchick', brands('github'), '#6e5494'],
@@ -12,8 +12,8 @@ const socialLinks = [
   ['mailto:eleni.arvanitis@me.com', solid('envelope'), '#fbbc05'],
 ]
 
-export default () => (
-  <Footer role='contentinfo'>
+const Footer = () => (
+  <StyledFooter role='contentinfo'>
     <Copyright>&copy; {`${new Date().getFullYear()} Eleni Konior`}</Copyright>
     <div>
       {socialLinks.map(link => (
@@ -30,5 +30,7 @@ export default () => (
         </Icon>
       ))}
     </div>
-  </Footer>
+  </StyledFooter>
 )
+
+export default Footer

--- a/client/components/Form.js
+++ b/client/components/Form.js
@@ -36,7 +36,7 @@ const getInputs = ({ name, email, message }) => [
   },
 ]
 
-export default () => {
+const Form = () => {
   const { addToast } = useToasts()
   const { executeRecaptcha } = useGoogleReCaptcha()
   const initialState = {
@@ -107,3 +107,5 @@ export default () => {
     </form>
   )
 }
+
+export default Form

--- a/client/components/Home.js
+++ b/client/components/Home.js
@@ -5,7 +5,7 @@ import { presets } from 'react-text-transition'
 import Button from '~/client/components/Button'
 import { Me, Carousel, Description } from '~/client/styles/home'
 
-export default () => {
+const Home = () => {
   const [idx, setIdx] = useState(0)
   const me = [
     ' a software engineer 👩🏻‍💻',
@@ -58,3 +58,5 @@ export default () => {
     </Me>
   )
 }
+
+export default Home

--- a/client/components/Link.jsx
+++ b/client/components/Link.jsx
@@ -1,9 +1,11 @@
 import React from 'react'
 
-import { Link } from '~/client/styles/link'
+import { StyledLink } from '~/client/styles/link'
 
-export default props => (
-  <Link rel='noopener' target='_blank' {...props}>
+const Link = props => (
+  <StyledLink rel='noopener' target='_blank' {...props}>
     {props.children}
-  </Link>
+  </StyledLink>
 )
+
+export default Link

--- a/client/components/Navbar.js
+++ b/client/components/Navbar.js
@@ -3,7 +3,7 @@ import { NavLink } from 'react-router-dom'
 
 import { Nav, Logo, StyledNavLink } from '~/client/styles/nav'
 
-export default () => (
+const Navbar = () => (
   <Nav role='navigation'>
     <NavLink to='/'>
       <Logo src='/assets/img/CreamLogo.png' alt='eak-logo-cream' />
@@ -15,3 +15,5 @@ export default () => (
     ))}
   </Nav>
 )
+
+export default Navbar

--- a/client/components/Work.js
+++ b/client/components/Work.js
@@ -7,7 +7,7 @@ import { ResumeButton } from '~/client/styles/button'
 
 import windowTrick from '~/client/window'
 
-export default () => {
+const Work = () => {
   windowTrick()
 
   return (
@@ -19,3 +19,5 @@ export default () => {
     </>
   )
 }
+
+export default Work

--- a/client/styles/about.js
+++ b/client/styles/about.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-export const About = styled.div`
+export const StyledAbout = styled.div`
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;

--- a/client/styles/button.js
+++ b/client/styles/button.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-export const Button = styled.button`
+export const StyledButton = styled.button`
   flex: 1 1 auto;
   margin: 10px auto;
   padding: 10px 25px;
@@ -46,13 +46,13 @@ export const Button = styled.button`
   }
 `
 
-export const ResumeButton = styled(Button)`
+export const ResumeButton = styled(StyledButton)`
   position: relative;
   display: flex;
   align-items: center;
 `
 
-export const ProjectLinkButton = styled(Button)`
+export const ProjectLinkButton = styled(StyledButton)`
   margin: 4% 1% 0 1%;
 
   @media (min-width: 0px) and (max-width: 767px) {
@@ -60,7 +60,7 @@ export const ProjectLinkButton = styled(Button)`
   }
 `
 
-export const SubmitButton = styled(Button)`
+export const SubmitButton = styled(StyledButton)`
   margin: 10% auto;
   padding: 4% 12%;
 `

--- a/client/styles/contact.js
+++ b/client/styles/contact.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-export const Contact = styled.div`
+export const StyledContact = styled.div`
   overflow: hidden;
   padding: 0 5% 3% 5%;
 `

--- a/client/styles/footer.js
+++ b/client/styles/footer.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-export const Footer = styled.footer`
+export const StyledFooter = styled.footer`
   position: fixed;
   margin-bottom: 0;
   bottom: 0;

--- a/client/styles/link.js
+++ b/client/styles/link.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-export const Link = styled.a`
+export const StyledLink = styled.a`
   text-decoration: none;
   position: relative;
   color: ghostwhite;

--- a/dev.js
+++ b/dev.js
@@ -70,7 +70,7 @@ firebaseUrl.then(FIREBASE_SERVE_URL =>
   spawn(
     '🌍  webpack dev server',
     'npx',
-    ['webpack', 'serve', '--open', ...process.argv.slice(2)],
+    ['webpack', 'serve', '--hot', '--open', ...process.argv.slice(2)],
     {
       env: Object.assign(
         {

--- a/main.js
+++ b/main.js
@@ -19,3 +19,6 @@ function main() {
 }
 
 main()
+
+// eslint-disable-next-line no-undef
+import.meta.webpackHot && import.meta.webpackHot.accept('~/client/App', main)

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@babel/preset-react": "^7.16.7",
         "@babel/runtime": "^7.17.9",
         "@hot-loader/react-dom": "^17.0.2",
+        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
         "babel-loader": "^8.2.4",
         "babel-plugin-macros": "^3.1.0",
         "babel-plugin-styled-components": "^2.0.7",
@@ -48,7 +49,7 @@
         "lint-staged": "^12.3.7",
         "prettier": "^2.6.2",
         "react-async-script": "^1.2.0",
-        "react-hot-loader": "^4.13.0",
+        "react-refresh": "^0.13.0",
         "react-test-renderer": "^17.0.2",
         "strip-ansi": "^7.0.1",
         "style-loader": "^3.3.1",
@@ -3387,6 +3388,129 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.7.tgz",
+      "integrity": "sha512-bcKCAzF0DV2IIROp9ZHkRJa6O4jy7NlnHdWL3GmcUxYWNjLXkK5kfELELwEfSP5hXPfVL/qOGMAROuMQb9GG8Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-html-community": "^0.0.8",
+        "common-path-prefix": "^3.0.0",
+        "core-js-pure": "^3.8.1",
+        "error-stack-parser": "^2.0.6",
+        "find-up": "^5.0.0",
+        "html-entities": "^2.1.0",
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0",
+        "source-map": "^0.7.3"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "@types/webpack": "4.x || 5.x",
+        "react-refresh": ">=0.10.0 <1.0.0",
+        "sockjs-client": "^1.4.0",
+        "type-fest": ">=0.17.0 <3.0.0",
+        "webpack": ">=4.43.0 <6.0.0",
+        "webpack-dev-server": "3.x || 4.x",
+        "webpack-hot-middleware": "2.x",
+        "webpack-plugin-serve": "0.x || 1.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/webpack": {
+          "optional": true
+        },
+        "sockjs-client": {
+          "optional": true
+        },
+        "type-fest": {
+          "optional": true
+        },
+        "webpack-dev-server": {
+          "optional": true
+        },
+        "webpack-hot-middleware": {
+          "optional": true
+        },
+        "webpack-plugin-serve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/schema-utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/source-map": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -5117,6 +5241,12 @@
         "node": ">= 12"
       }
     },
+    "node_modules/common-path-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
+      "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
+      "dev": true
+    },
     "node_modules/common-tags": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
@@ -5304,6 +5434,17 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/core-js-pure": {
+      "version": "3.22.6",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.22.6.tgz",
+      "integrity": "sha512-u5yG2VL6NKXz9BZHr9RAm6eWD1DTNjG7jJnJgLGR+Im0whdPcPXqwqxd+dcUrZvpvPan5KMgn/3pI+Q/aGqPOA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-util-is": {
@@ -5599,12 +5740,6 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
       "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
     },
-    "node_modules/dom-walk": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
-      "dev": true
-    },
     "node_modules/dot-prop": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
@@ -5790,6 +5925,15 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.7.tgz",
+      "integrity": "sha512-chLOW0ZGRf4s8raLrDxa5sdkvPec5YdvwbFnqJme4rk0rFajP8mPtrDL1+I+CwrQDCjswDA5sREX7jYQDQs9vA==",
+      "dev": true,
+      "dependencies": {
+        "stackframe": "^1.1.1"
       }
     },
     "node_modules/es-abstract": {
@@ -21331,16 +21475,6 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
     },
-    "node_modules/global": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-      "dev": true,
-      "dependencies": {
-        "min-document": "^2.19.0",
-        "process": "^0.11.10"
-      }
-    },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -24649,15 +24783,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "dev": true,
-      "dependencies": {
-        "dom-walk": "^0.1.0"
-      }
-    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -24674,12 +24799,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -25016,7 +25135,6 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -25380,15 +25498,6 @@
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -25629,80 +25738,19 @@
         "react-dom": "^17.0"
       }
     },
-    "node_modules/react-hot-loader": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.13.0.tgz",
-      "integrity": "sha512-JrLlvUPqh6wIkrK2hZDfOyq/Uh/WeVEr8nc7hkn2/3Ul0sx1Kr5y4kOGNacNRoj7RhwLNcQ3Udf1KJXrqc0ZtA==",
-      "dev": true,
-      "dependencies": {
-        "fast-levenshtein": "^2.0.6",
-        "global": "^4.3.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "loader-utils": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.1.0",
-        "source-map": "^0.7.3"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "@types/react": "^15.0.0 || ^16.0.0 || ^17.0.0 ",
-        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 ",
-        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 "
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-hot-loader/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/react-hot-loader/node_modules/loader-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-      "dev": true,
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/react-hot-loader/node_modules/source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/react-is": {
       "version": "18.1.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
       "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg=="
     },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "dev": true
+    "node_modules/react-refresh": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz",
+      "integrity": "sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/react-router": {
       "version": "6.3.0",
@@ -26608,6 +26656,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/stackframe": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.1.tgz",
+      "integrity": "sha512-h88QkzREN/hy8eRdyNhhsO7RSJ5oyTqxxmmn0dzBIMUclZsjpfmrsg81vp8mjjAs2vAZ72nyWxRUwSwmh0e4xg==",
+      "dev": true
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -28527,7 +28581,6 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
-      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -31007,6 +31060,70 @@
       "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==",
       "dev": true
     },
+    "@pmmmwh/react-refresh-webpack-plugin": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.7.tgz",
+      "integrity": "sha512-bcKCAzF0DV2IIROp9ZHkRJa6O4jy7NlnHdWL3GmcUxYWNjLXkK5kfELELwEfSP5hXPfVL/qOGMAROuMQb9GG8Q==",
+      "dev": true,
+      "requires": {
+        "ansi-html-community": "^0.0.8",
+        "common-path-prefix": "^3.0.0",
+        "core-js-pure": "^3.8.1",
+        "error-stack-parser": "^2.0.6",
+        "find-up": "^5.0.0",
+        "html-entities": "^2.1.0",
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0",
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "schema-utils": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        },
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        }
+      }
+    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -32424,6 +32541,12 @@
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "dev": true
     },
+    "common-path-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
+      "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
+      "dev": true
+    },
     "common-tags": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
@@ -32568,6 +32691,12 @@
           "dev": true
         }
       }
+    },
+    "core-js-pure": {
+      "version": "3.22.6",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.22.6.tgz",
+      "integrity": "sha512-u5yG2VL6NKXz9BZHr9RAm6eWD1DTNjG7jJnJgLGR+Im0whdPcPXqwqxd+dcUrZvpvPan5KMgn/3pI+Q/aGqPOA==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -32787,12 +32916,6 @@
         }
       }
     },
-    "dom-walk": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
-      "dev": true
-    },
     "dot-prop": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
@@ -32939,6 +33062,15 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "error-stack-parser": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.7.tgz",
+      "integrity": "sha512-chLOW0ZGRf4s8raLrDxa5sdkvPec5YdvwbFnqJme4rk0rFajP8mPtrDL1+I+CwrQDCjswDA5sREX7jYQDQs9vA==",
+      "dev": true,
+      "requires": {
+        "stackframe": "^1.1.1"
       }
     },
     "es-abstract": {
@@ -45403,16 +45535,6 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
     },
-    "global": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-      "dev": true,
-      "requires": {
-        "min-document": "^2.19.0",
-        "process": "^0.11.10"
-      }
-    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -47928,15 +48050,6 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
-    "min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "dev": true,
-      "requires": {
-        "dom-walk": "^0.1.0"
-      }
-    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -47950,12 +48063,6 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -48205,7 +48312,6 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "yocto-queue": "^0.1.0"
       }
@@ -48442,12 +48548,6 @@
         "react-is": "^18.0.0"
       }
     },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true
-    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -48649,59 +48749,15 @@
         "hoist-non-react-statics": "^3.3.2"
       }
     },
-    "react-hot-loader": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.13.0.tgz",
-      "integrity": "sha512-JrLlvUPqh6wIkrK2hZDfOyq/Uh/WeVEr8nc7hkn2/3Ul0sx1Kr5y4kOGNacNRoj7RhwLNcQ3Udf1KJXrqc0ZtA==",
-      "dev": true,
-      "requires": {
-        "fast-levenshtein": "^2.0.6",
-        "global": "^4.3.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "loader-utils": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.1.0",
-        "source-map": "^0.7.3"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
-        "loader-utils": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^1.0.1"
-          }
-        },
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
-        }
-      }
-    },
     "react-is": {
       "version": "18.1.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
       "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg=="
     },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+    "react-refresh": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz",
+      "integrity": "sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==",
       "dev": true
     },
     "react-router": {
@@ -49434,6 +49490,12 @@
           "dev": true
         }
       }
+    },
+    "stackframe": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.1.tgz",
+      "integrity": "sha512-h88QkzREN/hy8eRdyNhhsO7RSJ5oyTqxxmmn0dzBIMUclZsjpfmrsg81vp8mjjAs2vAZ72nyWxRUwSwmh0e4xg==",
+      "dev": true
     },
     "statuses": {
       "version": "2.0.1",
@@ -50884,8 +50946,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
-      "optional": true
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     }
   },
   "scripts": {
-    "build": "webpack --mode development",
-    "build:prod": "webpack --mode production",
+    "build": "webpack build --mode development",
+    "build:prod": "webpack build --mode production",
     "clean": "rm public/*.bundle.js public/*.hot-update.js*",
     "deploy": "npm run build:prod && npx firebase deploy",
     "lint": "eslint . --ext .js,.jsx",
@@ -51,6 +51,7 @@
     "@babel/preset-react": "^7.16.7",
     "@babel/runtime": "^7.17.9",
     "@hot-loader/react-dom": "^17.0.2",
+    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
     "babel-loader": "^8.2.4",
     "babel-plugin-macros": "^3.1.0",
     "babel-plugin-styled-components": "^2.0.7",
@@ -69,7 +70,7 @@
     "lint-staged": "^12.3.7",
     "prettier": "^2.6.2",
     "react-async-script": "^1.2.0",
-    "react-hot-loader": "^4.13.0",
+    "react-refresh": "^0.13.0",
     "react-test-renderer": "^17.0.2",
     "strip-ansi": "^7.0.1",
     "style-loader": "^3.3.1",

--- a/public/serviceWorker.js
+++ b/public/serviceWorker.js
@@ -1,21 +1,27 @@
+const CACHE_NAME = 'v1'
 const urlsToCache = [
-    '.',
-    '/assets/styles/index.css',
-    '/assets/styles/contact.css',
-    '/assets/img/CreamLogo.png',
-    '/client/styles/home.js',
-    '/client/styles/button.js',
-    '/client/styles/nav.js',
-    '/client/styles/footer.js',
-    '/client/styles/about.js',
-    '/client/styles/work.js',
-    '/client/styles/articles.js',
-    '/client/styles/contact.js',
-    'main.bundle.js',
-    'index.html',
-    'https://fonts.googleapis.com/css?family=Open+Sans:300,800',
-  ],
-  CACHE_NAME = 'v1'
+  '.',
+  '/assets/styles/index.css',
+  '/assets/styles/contact.css',
+  '/assets/img/CreamLogo.png',
+  '/client/styles/home.js',
+  '/client/styles/button.js',
+  '/client/styles/nav.js',
+  '/client/styles/footer.js',
+  '/client/styles/about.js',
+  '/client/styles/work.js',
+  '/client/styles/articles.js',
+  '/client/styles/contact.js',
+  'main.bundle.js',
+  'index.html',
+  'https://fonts.googleapis.com/css?family=Open+Sans:300,800',
+]
+
+// https://stackoverflow.com/a/70863551
+const containsChromeExtension = ({ url }) =>
+  url.startsWith('chrome-extension') ||
+  url.includes('extension') ||
+  url.startsWith('http')
 
 self.addEventListener('install', evt => {
   // Perform install steps
@@ -28,6 +34,10 @@ self.addEventListener('install', evt => {
 })
 
 self.addEventListener('fetch', evt => {
+  if (containsChromeExtension(evt.request)) {
+    return;
+  }
+
   evt.respondWith(
     caches.match(evt.request).then(res => {
       // Cache hit - return response
@@ -45,10 +55,9 @@ self.addEventListener('fetch', evt => {
           return res
         }
 
-        // IMPORTANT: Clone the response. A response is a stream
-        // and because we want the browser to consume the response
-        // as well as the cache consuming the response, we need
-        // to clone it so we have two streams.
+        // IMPORTANT: Clone the response. A response is a stream and because we
+        // want the browser to consume the response as well as the cache
+        // consuming the response, we need to clone it so we have two streams.
         const responseToCache = res.clone()
 
         caches.open(CACHE_NAME).then(cache => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,8 @@
 import { resolve } from 'path'
 
-import { GenerateSW } from 'workbox-webpack-plugin'
+import ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin'
 import Dotenv from 'dotenv-webpack'
+import { GenerateSW } from 'workbox-webpack-plugin'
 
 import babel from './babel.config.js'
 
@@ -11,7 +12,7 @@ const isHot = env => !isProd(env)
 const __dirname = resolve()
 
 const config = env => ({
-  entry: ['react-hot-loader/patch', './main.js'],
+  entry: './main.js',
   mode: isHot(env) ? 'development' : 'production',
   output: {
     filename: '[name].bundle.js',
@@ -22,7 +23,6 @@ const config = env => ({
     extensions: ['.jsx', '.js', '.json'],
     alias: {
       '~': __dirname,
-      'react-dom': '@hot-loader/react-dom',
     },
   },
   devServer: devServer(env),
@@ -80,7 +80,7 @@ const config = env => ({
 const plugins = env => {
   const commonPlugins = [new Dotenv({ systemvars: true })]
   return isHot(env)
-    ? [...commonPlugins]
+    ? [...commonPlugins, new ReactRefreshWebpackPlugin()]
     : [
         ...commonPlugins,
         new GenerateSW({


### PR DESCRIPTION
- No longer leverage unnamed exports that rely on the filename 😭 
- Uninstall `react-hot-loader` in favor of experimental (but officially supported) `react-refresh`
- Modify `serviceWorker.js` in order to ignore any chrome extensions or non-secure (HTTP) traffic
  - I also manually deleted everything in `~/Library/Application\ Support/Google/Chrome/Profile\ 3/Local\ Storage/leveldb/` (running `rm -r`) because Chrome was not refreshing in Dev Tools -> Application -> Storage
- Update `webpack` commands to be more explicit

I was able to successfully see hot reloading files autogenerate into the `public` directory once again! However, now HMR will refresh the entire page each time rather than, well, hot loading. I'll dig into that at a later time.