### PR TITLE
refactor: extract a layer of indirection around a tags

### DIFF
--- a/client/components/Link.jsx
+++ b/client/components/Link.jsx
@@ -1,11 +1,9 @@
 import React from 'react'
 
-import { StyledLink } from '~/client/styles/link'
-
 const Link = props => (
-  <StyledLink rel='noopener' target='_blank' {...props}>
+  <a rel='noopener' target='_blank' {...props}>
     {props.children}
-  </StyledLink>
+  </a>
 )
 
 export default Link

--- a/client/styles/GlobalStyles.js
+++ b/client/styles/GlobalStyles.js
@@ -19,6 +19,11 @@ const GlobalStyle = createGlobalStyle`
     font-family: ${props => props.theme.fontFamily};
   }
 
+  a {
+    text-decoration: none;
+    position: relative;
+  }
+
   *:focus {
     outline: none;
   }

--- a/client/styles/link.js
+++ b/client/styles/link.js
@@ -1,7 +1,0 @@
-import styled from 'styled-components'
-
-export const StyledLink = styled.a`
-  text-decoration: none;
-  position: relative;
-  color: ghostwhite;
-`


### PR DESCRIPTION
- remove `StyledLink` component in favor of `Link` component, which uses an `a` tag directly
- delete `client/styles/link.js`
  - place what was in this file into `GlobalStyles.js`