### PR TITLE
refactor: normalize header styles

### DIFF
--- a/client/components/About.js
+++ b/client/components/About.js
@@ -2,11 +2,12 @@ import React from 'react'
 import { NavLink } from 'react-router-dom'
 
 import Button from '~/client/components/Button'
-import { StyledAbout, AboutHeader, AboutText } from '~/client/styles/about'
+import { StyledAbout, AboutText } from '~/client/styles/about'
+import { Header } from '~/client/styles'
 
 const About = () => (
   <StyledAbout>
-    <AboutHeader>Creating useful and engaging software</AboutHeader>
+    <Header fontSize='30'>Creating useful and engaging software</Header>
     <AboutText>
       <p>
         Every day I get to ride the insatiable roller coaster that is software

--- a/client/components/Contact.js
+++ b/client/components/Contact.js
@@ -3,19 +3,15 @@ import Form from '~/client/components/Form'
 
 import windowTrick from '~/client/window'
 
-import {
-  StyledContact,
-  ContactForm,
-  H2,
-  Disclaimer,
-} from '~/client/styles/contact'
+import { StyledContact, ContactForm, Disclaimer } from '~/client/styles/contact'
+import { Header } from '~/client/styles'
 
 const Contact = () => {
   windowTrick()
 
   return (
     <StyledContact>
-      <H2>Let&apos;s Work Together!</H2>
+      <Header fontSize='60'>Let&apos;s Work Together!</Header>
       <ContactForm>
         <span>
           <Form />

--- a/client/styles/about.js
+++ b/client/styles/about.js
@@ -18,16 +18,6 @@ export const StyledAbout = styled.div`
   }
 `
 
-export const AboutHeader = styled.p`
-  font-size: 35pt;
-  font-weight: 800;
-  margin-bottom: 4%;
-
-  @media (min-width: 320px) and (max-width: 1024px) {
-    font-size: 30pt;
-  }
-`
-
 export const AboutText = styled.div`
   font-size: 14pt;
 `

--- a/client/styles/contact.js
+++ b/client/styles/contact.js
@@ -42,15 +42,6 @@ export const TextArea = styled.textarea`
   ${inputAndTextAreaStyles}
 `
 
-export const H2 = styled.h2`
-  font-size: 60pt;
-
-  @media (min-width: 320px) and (max-width: 480px) {
-    font-size: 49pt;
-    margin: 5% auto 15% auto;
-  }
-`
-
 export const Disclaimer = styled.p`
   font-size: 5pt;
   font-style: italic;

--- a/client/styles/index.js
+++ b/client/styles/index.js
@@ -1,0 +1,5 @@
+import styled from 'styled-components'
+
+export const Header = styled.h1`
+  font-size: ${props => props.fontSize}pt;
+`


### PR DESCRIPTION
- create `client/styles/index.js` to put in styles that will work throughout the app
- extract headers from `About` and `Contact` in favor of one easy `Header` styled component that will take in a `fontSize` prop
- Delete `p` and `h2` styled components in above files that required extra CSS to feel right given they were not h1s