### PR TITLE
fix: react-text-transition requires children as text value

### DIFF
--- a/client/components/Home.js
+++ b/client/components/Home.js
@@ -34,13 +34,10 @@ const Home = () => {
   return (
     <Me>
       <span>
-        I am <span />
-        <Carousel
-          direction='up'
-          inline={true}
-          text={me[idx % me.length]}
-          springConfig={presets.gentle}
-        />
+        I am{' '}
+        <Carousel direction='up' springConfig={presets.gentle} inline>
+          {me[idx % me.length]}
+        </Carousel>
       </span>
       <Description>
         After graduating from NYU with a B.A. in Economics, I decided to tap


### PR DESCRIPTION
- Prefer `{' '}` for extra space between `I am` and anything rendered by `react-text-transition` rather than using a nested `<span />`
- Switch out `text` prop value as a child of `<Carousel>` since `react-text-transition` was seemingly updated (docs still mention that `text` is a required prop, but I found that to be out of date)
- Use `inline` without explicitly assigning it to `true` (Fun lint tip I learned at work! If you pass it in this way, it is assigning it as true. If you need something to be `false`, that you have to assign explicitly.)