### PR TITLE
refactor: simplify contact form and center styles

### DIFF
--- a/client/components/Contact.js
+++ b/client/components/Contact.js
@@ -3,7 +3,7 @@ import Form from '~/client/components/Form'
 
 import windowTrick from '~/client/window'
 
-import { StyledContact, ContactForm, Disclaimer } from '~/client/styles/contact'
+import { StyledContact, Disclaimer } from '~/client/styles/contact'
 import { Header } from '~/client/styles'
 
 const Contact = () => {
@@ -11,16 +11,12 @@ const Contact = () => {
 
   return (
     <StyledContact>
-      <Header fontSize='60'>Let&apos;s Work Together!</Header>
-      <ContactForm>
-        <span>
-          <Form />
-          <Disclaimer>
-            This site is protected by reCAPTCHA and the Google Privacy Policy
-            and Terms of Service apply.
-          </Disclaimer>
-        </span>
-      </ContactForm>
+      <Header fontSize='45'>Let&apos;s Work Together!</Header>
+      <Form />
+      <Disclaimer>
+        This site is protected by reCAPTCHA and the Google Privacy Policy and
+        Terms of Service apply.
+      </Disclaimer>
     </StyledContact>
   )
 }

--- a/client/components/Form.js
+++ b/client/components/Form.js
@@ -7,7 +7,7 @@ import { useToasts } from 'react-toast-notifications'
 import emailjs from '@emailjs/browser'
 
 import { Submit } from '~/client/components/Button'
-import { Input, TextArea } from '~/client/styles/contact'
+import { Asterisk, Input, StyledForm, TextArea } from '~/client/styles/contact'
 
 // emailJS IDs
 const serviceId = process.env.EMAILJS_SERVICE_ID
@@ -84,7 +84,7 @@ const Form = () => {
 
   const inputs = getInputs(state)
   return (
-    <form onSubmit={sendEmail}>
+    <StyledForm onSubmit={sendEmail}>
       {inputs.map(({ type, name, placeholder, value }) => {
         const inputProps = {
           name,
@@ -95,17 +95,18 @@ const Form = () => {
 
         return (
           <label key={name}>
+            <Asterisk />
+            {name.charAt(0).toUpperCase() + name.slice(1)}
             {name !== 'message' ? (
               <Input type={type} required {...inputProps} />
             ) : (
               <TextArea required {...inputProps} />
             )}
-            <br />
           </label>
         )
       })}
       <Submit onClick={verifyHumanity} />
-    </form>
+    </StyledForm>
   )
 }
 

--- a/client/styles/button.js
+++ b/client/styles/button.js
@@ -61,6 +61,6 @@ export const ProjectLinkButton = styled(StyledButton)`
 `
 
 export const SubmitButton = styled(StyledButton)`
-  margin: 10% auto;
-  padding: 4% 12%;
+  margin: 0 auto 8% auto;
+  padding: 3% 10%;
 `

--- a/client/styles/button.js
+++ b/client/styles/button.js
@@ -62,5 +62,4 @@ export const ProjectLinkButton = styled(StyledButton)`
 
 export const SubmitButton = styled(StyledButton)`
   margin: 0 auto 8% auto;
-  padding: 3% 10%;
 `

--- a/client/styles/contact.js
+++ b/client/styles/contact.js
@@ -29,6 +29,7 @@ const inputAndTextAreaStyles = css`
 export const StyledForm = styled.form`
   display: flex;
   flex-flow: column nowrap;
+  justify-content: space-between;
   width: 50%;
 `
 

--- a/client/styles/contact.js
+++ b/client/styles/contact.js
@@ -1,26 +1,41 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 export const StyledContact = styled.div`
-  overflow: hidden;
-  padding: 0 5% 3% 5%;
-`
-
-export const ContactForm = styled.div`
   display: flex;
-  flex-flow: row wrap;
-  justify-content: space-between;
+  justify-content: center;
+  align-items: center;
+  flex-flow: column nowrap;
+  margin: 0 auto;
+  width: 80%;
+  text-align: center;
 `
 
-const inputAndTextAreaStyles = `
+const inputAndTextAreaStyles = css`
   font-size: 16pt;
-  width: calc(100% / 0.5);
+  text-align: center;
+  width: 100%;
   padding: 1% 0;
+  margin-bottom: 10%;
   background: transparent;
   border: transparent;
   border-bottom: 1.5px solid gray;
-  
-  @media (min-width: 320px) and (max-width: 480px) {
-    width: calc(100% / 0.75);
+
+  :focus {
+    border-bottom: 1.5px solid #e0bf9f;
+    transition: all 0.25s ease-in-out;
+  }
+`
+
+export const StyledForm = styled.form`
+  display: flex;
+  flex-flow: column nowrap;
+  width: 50%;
+`
+
+export const Asterisk = styled.label`
+  :after {
+    color: red;
+    content: '* ';
   }
 `
 
@@ -28,11 +43,6 @@ export const Input = styled.input`
   -webkit-backface-visibility: hidden;
   margin-bottom: 20%;
   ${inputAndTextAreaStyles}
-
-  :focus {
-    border-bottom: 1.5px solid #e0bf9f;
-    transition: all 0.25s ease-in-out;
-  }
 `
 
 export const TextArea = styled.textarea`


### PR DESCRIPTION
- Remove extra components that weren't adding anything of value (simplification)
  - Extra `<span />`
  - `<br />` after every form element
- Add in `Asterisk` and text to `label`s
- Reduce `/contact` header text to `45pt` from `60pt`
- Use `css` import from `styled-components` so that IDE brings up colors correctly
- Add a `StyledForm` component, without which the form wouldn't properly render (in terms of CSS)
- Reduce `SubmitButton` padding values, delete its margin values