### PR TITLE
refactor: remove extra empty div and background-image styles in /articles

### DIFF
--- a/client/components/Articles.js
+++ b/client/components/Articles.js
@@ -5,11 +5,11 @@ import Link from '~/client/components/Link'
 import Button from '~/client/components/Button'
 
 import {
+  Article,
   ArticleTitle,
   DatePosted,
   Description,
   StyledHr,
-  Article,
 } from '~/client/styles/articles'
 
 import db from '~/db/firebase'
@@ -24,17 +24,15 @@ const Articles = () => {
     []
   )
 
-  return articles.reverse().map(article => (
+  return articles.reverse().map((article, idx) => (
     <Article key={article.title}>
-      <>
-        <ArticleTitle>{article.title}</ArticleTitle>
-        <DatePosted>{article['date-posted']}</DatePosted>
-        <Description>{article.description}</Description>
-        <Link href={article.link}>
-          <Button text='Read More ↗' />
-        </Link>
-        <StyledHr />
-      </>
+      <ArticleTitle>{article.title}</ArticleTitle>
+      <DatePosted>{article['date-posted']}</DatePosted>
+      <Description>{article.description}</Description>
+      <Link href={article.link}>
+        <Button text='Read More ↗' />
+      </Link>
+      {idx !== articles.length - 1 && <StyledHr />}
     </Article>
   ))
 }


### PR DESCRIPTION
- Sort `Article` styled component to top of imports from `~/client/styles/articles.js`
- Delete unnecessary `React.Fragment`
- Add in `idx` to `articles.map` in order to remove the trailing line break for the last article on the page