### PR TITLE
refactor: make `Expand` more generic

### DIFF
--- a/client/components/Expand.js
+++ b/client/components/Expand.js
@@ -3,7 +3,7 @@ import { onSnapshot, collection } from 'firebase/firestore'
 
 import { ProjectLink } from '~/client/components/Button'
 import {
-  Project,
+  ProjectStyle,
   Lines,
   Role,
   Description,
@@ -14,64 +14,57 @@ import {
 import db from '~/db/firebase'
 
 const Expand = () => {
-  const [isHidden, setIsHidden] = useState(true)
-  const [selectedProject, setSelectedProject] = useState('')
-  const [projects, setProjects] = useState([])
+  const [isExpanded, setIsExpanded] = useState(false)
+  const [selectedItem, setSelectedItem] = useState('')
+  const [items, setItems] = useState([])
 
   useEffect(
     () =>
       onSnapshot(collection(db, 'projects'), snapshot =>
-        setProjects(snapshot.docs.map(doc => doc.data()))
+        setItems(snapshot.docs.map(doc => doc.data()))
       ),
     []
   )
 
   const toggle = evt => {
-    const project = evt.target.innerText
+    const item = evt.target.innerText
 
-    if (!selectedProject) {
-      setSelectedProject(project)
-    } else if (selectedProject && project !== selectedProject) {
-      // if there's a project expanded, but a different project was clicked
-      // then hide the current project, set the new project, then expand
-      // that new project
-      setIsHidden(true)
-      setSelectedProject(project)
-      setIsHidden(false)
+    if (!selectedItem) {
+      setSelectedItem(item)
+    } else if (selectedItem && item !== selectedItem) {
+      // if there's an expanded item, but a different item was clicked, then
+      // hide the current item, set the new item, then expand that new item
+      setIsExpanded(false)
+      setSelectedItem(item)
+      setIsExpanded(true)
     }
 
-    // if there isn't already a project expanded, or the same project
-    // was clicked, then set isHidden to the opposite value
-    if (!selectedProject || selectedProject === project) {
-      setIsHidden(!isHidden)
+    // if there isn't already an expanded item, or the same item was clicked,
+    // then set isExpanded to the opposite value
+    if (!selectedItem || selectedItem === item) {
+      setIsExpanded(!isExpanded)
     }
   }
 
-  return projects.map(p => {
-    const { name, role, description, technologies, links } = p
-
-    return (
-      <Project key={name}>
-        <>
-          <Lines onClick={toggle}>{name.toUpperCase()}</Lines>
-          {!isHidden && selectedProject === name.toUpperCase() && (
-            <Detail>
-              <Role>{role}</Role>
-              <Description>{description}</Description>
-              <br />
-              {technologies.map(technology => (
-                <Tech key={technology}>{technology.toUpperCase()}</Tech>
-              ))}
-              <br />
-              {links.map((link, i) => (
-                <ProjectLink key={`${name}-${link}${i}`} link={link} />
-              ))}
-            </Detail>
-          )}
-        </>
-      </Project>
-    )
-  })
+  return items.map(({ name, role, description, technologies, links }) => (
+    <ProjectStyle key={name}>
+      <Lines onClick={toggle}>{name.toUpperCase()}</Lines>
+      {isExpanded && selectedItem === name.toUpperCase() && (
+        <Detail>
+          <Role>{role}</Role>
+          <Description>{description}</Description>
+          <br />
+          {technologies.map(technology => (
+            <Tech key={technology}>{technology.toUpperCase()}</Tech>
+          ))}
+          <br />
+          {links.map((link, i) => (
+            <ProjectLink key={`${name}-${link}${i}`} link={link} />
+          ))}
+        </Detail>
+      )}
+    </ProjectStyle>
+  ))
 }
 
 export default Expand

--- a/client/styles/work.js
+++ b/client/styles/work.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-export const Project = styled.div`
+export const ProjectStyle = styled.div`
   align-items: center;
   justify-content: center;
   padding: 2% 0;


### PR DESCRIPTION
#### Motivation
This commit changes project-specific language in the `Expand` component to item-specific logic. This is a stepping stone to a larger refactor that will hopefully entire decouple project code from expansion code.

#### Changes
- rename `Project` to `ProjectStyle` in `client/styles/work.js`
- `client/components/Expand`
  - destruct project information from each project in the `items` map
  - eliminate the unnecessary `Fragment` in `Expand`
  - use item-specific instead of project-specific language