### PR TITLE
feature: create a custom hook `useExpansion`

### DIFF
--- a/client/components/Expand.js
+++ b/client/components/Expand.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { onSnapshot, collection } from 'firebase/firestore'
 
+import useExpansion from '~/client/hooks/useExpansion'
 import { ProjectLink } from '~/client/components/Button'
 import {
   ProjectStyle,
@@ -14,9 +15,8 @@ import {
 import db from '~/db/firebase'
 
 const Expand = () => {
-  const [isExpanded, setIsExpanded] = useState(false)
-  const [selectedItem, setSelectedItem] = useState('')
   const [items, setItems] = useState([])
+  const { toggle, isExpanded, expandedItem } = useExpansion()
 
   useEffect(
     () =>
@@ -26,30 +26,10 @@ const Expand = () => {
     []
   )
 
-  const toggle = evt => {
-    const item = evt.target.innerText
-
-    if (!selectedItem) {
-      setSelectedItem(item)
-    } else if (selectedItem && item !== selectedItem) {
-      // if there's an expanded item, but a different item was clicked, then
-      // hide the current item, set the new item, then expand that new item
-      setIsExpanded(false)
-      setSelectedItem(item)
-      setIsExpanded(true)
-    }
-
-    // if there isn't already an expanded item, or the same item was clicked,
-    // then set isExpanded to the opposite value
-    if (!selectedItem || selectedItem === item) {
-      setIsExpanded(!isExpanded)
-    }
-  }
-
   return items.map(({ name, role, description, technologies, links }) => (
     <ProjectStyle key={name}>
       <Lines onClick={toggle}>{name.toUpperCase()}</Lines>
-      {isExpanded && selectedItem === name.toUpperCase() && (
+      {isExpanded && expandedItem === name.toUpperCase() && (
         <Detail>
           <Role>{role}</Role>
           <Description>{description}</Description>

--- a/client/hooks/useExpansion.js
+++ b/client/hooks/useExpansion.js
@@ -1,0 +1,30 @@
+import { useCallback, useState } from 'react'
+
+const useExpansion = () => {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const [expandedItem, setExpandedItem] = useState('')
+
+  const toggle = useCallback(evt => {
+    const item = evt.target.innerText
+
+    if (!expandedItem) {
+      setExpandedItem(item)
+    } else if (expandedItem && item !== expandedItem) {
+      // if there's an expanded item, but a different item was clicked, then
+      // hide the current item, set the new item, then expand that new item
+      setIsExpanded(false)
+      setExpandedItem(item)
+      setIsExpanded(true)
+    }
+
+    // if there isn't already an expanded item, or the same item was clicked,
+    // then set isExpanded to the opposite value
+    if (!expandedItem || expandedItem === item) {
+      setIsExpanded(!isExpanded)
+    }
+  }, [])
+
+  return { toggle, isExpanded, expandedItem }
+}
+
+export default useExpansion


### PR DESCRIPTION
#### Motivation
Previously, any expansion-related code was coupled very tightly in the `Expand` component. While this component still exists, any `toggle` logic is now moved into the new `useExpansion` hook.

The next move is to extract any project-specific presentation logic into its own component and pull that into `Work`, thereby removing the need for `Expand` as a component entirely.

#### Changes
- Create `useExpansion` hook
- Use the new hook in `Expand` component