### PR TITLE
feat: create hamburger menu

### DIFF
--- a/client/components/Hamburger.jsx
+++ b/client/components/Hamburger.jsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react'
+import { Sling } from 'hamburger-react'
+
+import { MenuItem, MenuList, StyledNavLink } from '~/client/styles/nav'
+
+const LINKS = ['Home', 'About', 'Work', 'Articles', 'Contact']
+
+const Hamburger = () => {
+  const [open, setOpen] = useState(false)
+  const toggleMenu = () => setOpen(!open)
+
+  return (
+    <>
+      <Sling
+        direction='left'
+        toggled={open}
+        toggle={toggleMenu}
+        label='Toggle menu'
+        isOpen={open}
+      />
+      {open && (
+        <MenuList>
+          {LINKS.map(link => (
+            <MenuItem key={link}>
+              <StyledNavLink
+                to={link === 'Home' ? '/' : `/${link.toLowerCase()}`}
+                onClick={toggleMenu}
+              >
+                {link}
+              </StyledNavLink>
+            </MenuItem>
+          ))}
+        </MenuList>
+      )}
+    </>
+  )
+}
+
+export default Hamburger

--- a/client/components/Navbar.js
+++ b/client/components/Navbar.js
@@ -1,7 +1,9 @@
 import React from 'react'
 import { NavLink, Outlet } from 'react-router-dom'
 
-import { Nav, Logo, StyledNavLink } from '~/client/styles/nav'
+import Hamburger from '~/client/components/Hamburger'
+
+import { Nav, Logo } from '~/client/styles/nav'
 
 const Navbar = () => (
   <>
@@ -9,11 +11,7 @@ const Navbar = () => (
       <NavLink to='/'>
         <Logo src='/assets/img/CreamLogo.png' alt='eak-logo-cream' />
       </NavLink>
-      {['About', 'Work', 'Articles', 'Contact'].map(link => (
-        <StyledNavLink key={link} to={`/${link.toLowerCase()}`}>
-          {link}
-        </StyledNavLink>
-      ))}
+      <Hamburger />
     </Nav>
     <Outlet />
   </>

--- a/client/styles/footer.js
+++ b/client/styles/footer.js
@@ -10,6 +10,7 @@ export const StyledFooter = styled.footer`
   display: flex;
   justify-content: space-between;
   background-color: rgba(0, 0, 0, 1);
+  z-index: 2;
 `
 
 export const Copyright = styled.span`

--- a/client/styles/nav.js
+++ b/client/styles/nav.js
@@ -7,28 +7,38 @@ export const Nav = styled.nav`
   font-weight: 800;
   color: ghostwhite;
   display: flex;
-  justify-content: space-around;
-  align-items: flex-end;
-  margin: 0;
-  padding: 1rem 0;
-  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+  margin: 0 2%;
+  padding: 1rem;
   vertical-align: text-top;
-
-  @media (min-width: 320px) and (max-width: 480px) {
-    font-size: 13px;
-  }
 `
 
 export const Logo = styled.img`
-  min-width: 25px;
-  max-height: 35px;
-  display: inline-flex;
-  float: left;
+  display: flex;
+  align-items: center;
+  min-width: 15%;
+  max-height: 30px;
+`
 
-  @media (min-width: 320px) and (max-width: 480px) {
-    max-width: 25px;
-    max-height: 40px;
-  }
+export const MenuList = styled.ul`
+  list-style: none;
+  flex-direction: column;
+  text-align: center;
+  margin: 0;
+  padding: 0;
+  position: fixed;
+  top: 10%;
+  z-index: 1;
+  left: 0;
+  width: 100%;
+  height: calc(100% - 4rem);
+  background-color: rgba(0, 0, 0, 1);
+`
+
+export const MenuItem = styled.li`
+  margin: 0;
+  padding: 1%;
 `
 
 export const StyledNavLink = styled(NavLink)`

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@reduxjs/toolkit": "^1.9.5",
         "firebase": "^9.21.0",
+        "hamburger-react": "^2.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-google-recaptcha-v3": "^1.10.1",
@@ -18925,6 +18926,14 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/hamburger-react": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hamburger-react/-/hamburger-react-2.5.0.tgz",
+      "integrity": "sha512-5GSXe+ucxTPJ0SkhIsPQ/PRDweZPIKya1lfahAuExx31SdheeUA4uOPfQIAirbKona8hvo79VDr5LJQzPXsdpw==",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18"
       }
     },
     "node_modules/handle-thing": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@reduxjs/toolkit": "^1.9.5",
     "firebase": "^9.21.0",
+    "hamburger-react": "^2.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-google-recaptcha-v3": "^1.10.1",


### PR DESCRIPTION
Previously, this website had all the links displayed at the top of the header. The setup was nice enough, but it got smushed on smaller viewports and didn't leave much room for new routes.

This commit takes out much of the navigation header, maintaining the logo at the top-left corner, and places all routes in a hamburger component using `Sling` from `hamburger-react`.

When open, the hamburger menu opens up and will only show its contents, the header, and the footer. When closed, the page will appear as it did previously.

Changes:
- Adds hamburger menu
- Deletes navigation items except for logo
- Modifies footer styles to remain present when hamburger menu is open

RESOLVES #55