### PR TITLE
refactor: clean up `<About />` styles

### DIFF
--- a/client/components/About.js
+++ b/client/components/About.js
@@ -9,17 +9,7 @@ const StyledAbout = styled.div`
   display: flex;
   flex-flow: column wrap;
   margin: 0 auto;
-  width: 60%;
-
-  @media (min-width: 0px) and (max-width: 319px) {
-    padding-right: 1%;
-  }
-
-  @media (min-width: 0px) and (max-width: 1024px) {
-    margin: 0 auto;
-    padding-left: 8%;
-    padding-right: 8%;
-  }
+  width: 65%;
 `
 
 const About = () => (


### PR DESCRIPTION
Non-browser-specific viewport styles weren't necessary, so this commit cleans this up