### PR TITLE
chore(lint): add sort-imports to eslint ruleset

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,10 @@
   },
   "rules": {
     "react/display-name": 0,
-    "react/prop-types": 0
+    "react/prop-types": 0,
+    "sort-imports": ["error", {
+      "memberSyntaxSortOrder": ["single", "all", "multiple", "none"],
+      "allowSeparatedGroups": true
+    }]
   }
 }

--- a/client/App.jsx
+++ b/client/App.jsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import { RouterProvider, createBrowserRouter } from 'react-router-dom'
 
-import Navbar from '~/client/components/Navbar'
 import About from '~/client/components/About'
-import Home from '~/client/components/Home'
-import Work from '~/client/components/Work'
 import Articles from '~/client/components/Articles'
 import Contact from '~/client/components/Contact'
 import Footer from '~/client/components/Footer'
+import Home from '~/client/components/Home'
+import Navbar from '~/client/components/Navbar'
+import Work from '~/client/components/Work'
 
 const createChild = (path, element) => ({ path, element })
 

--- a/client/components/About.js
+++ b/client/components/About.js
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import { NavLink } from 'react-router-dom'
 import styled from 'styled-components'
 

--- a/client/components/Articles.js
+++ b/client/components/Articles.js
@@ -3,8 +3,8 @@ import styled from 'styled-components'
 
 import { useFetchArticlesQuery } from '~/api/index'
 
-import Link from '~/client/components/Link'
 import Button from '~/client/components/Button'
+import Link from '~/client/components/Link'
 
 const StyledHr = styled.hr`
   border-color: #e0bf9f;

--- a/client/components/Button.jsx
+++ b/client/components/Button.jsx
@@ -3,8 +3,8 @@ import React from 'react'
 import Link from '~/client/components/Link'
 
 import {
-  StyledButton,
   ProjectLinkButton,
+  StyledButton,
   SubmitButton,
 } from '~/client/styles/button'
 

--- a/client/components/Contact.js
+++ b/client/components/Contact.js
@@ -1,8 +1,9 @@
 import React from 'react'
+
 import Form from '~/client/components/Form'
 
-import { StyledContact, Disclaimer } from '~/client/styles/contact'
 import { Header } from '~/client/styles'
+import { Disclaimer, StyledContact } from '~/client/styles/contact'
 
 const Contact = () => (
   <StyledContact>

--- a/client/components/Footer.js
+++ b/client/components/Footer.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { brands, solid } from '@fortawesome/fontawesome-svg-core/import.macro'
 

--- a/client/components/Form.js
+++ b/client/components/Form.js
@@ -1,10 +1,10 @@
 /* eslint no-undef: 0 */
 
-import React, { useState, useCallback } from 'react'
-import { useGoogleReCaptcha } from 'react-google-recaptcha-v3'
-import toast, { Toaster } from 'react-hot-toast'
+import React, { useCallback, useState } from 'react'
 
 import emailjs from '@emailjs/browser'
+import { useGoogleReCaptcha } from 'react-google-recaptcha-v3'
+import toast, { Toaster } from 'react-hot-toast'
 
 import { Submit } from '~/client/components/Button'
 import { Asterisk, Input, StyledForm, TextArea } from '~/client/styles/contact'

--- a/client/components/Hamburger.jsx
+++ b/client/components/Hamburger.jsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react'
-import styled from 'styled-components'
+
 import { NavLink } from 'react-router-dom'
 import { Sling } from 'hamburger-react'
+import styled from 'styled-components'
 
 const MenuList = styled.ul`
   list-style: none;

--- a/client/components/Home.js
+++ b/client/components/Home.js
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
+
 import { NavLink } from 'react-router-dom'
-import TextTransition, { presets } from 'react-text-transition'
 import styled from 'styled-components'
+import TextTransition, { presets } from 'react-text-transition'
 
 import Button from '~/client/components/Button'
 

--- a/client/components/Work.js
+++ b/client/components/Work.js
@@ -2,8 +2,8 @@ import React from 'react'
 
 import { useFetchProjectsQuery } from '~/api/index'
 
-import { ProjectLink } from '~/client/components/Button'
 import Link from '~/client/components/Link'
+import { ProjectLink } from '~/client/components/Button'
 import useExpansion from '~/client/hooks/useExpansion'
 
 import { ResumeButton } from '~/client/styles/button'

--- a/db/firebase.js
+++ b/db/firebase.js
@@ -1,4 +1,4 @@
-/* eslint no-undef: 0 */
+/* eslint no-undef: 0, sort-imports: 0 */
 
 import { initializeApp } from 'firebase/app'
 import { getFirestore } from 'firebase/firestore'

--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
+
 import { GoogleReCaptchaProvider } from 'react-google-recaptcha-v3'
 import { ThemeProvider } from 'styled-components'
 


### PR DESCRIPTION
- Sets `sort-imports` rule within `.eslintrc.json`
- Sorts imports based on this rule configuration, personally preferred sort order, and maintains order where necessary (`React` needs to come first, for instance)

Since `db/firebase.js` already ignored one lint error, I also ignored this new rule there so that the current order is maintained as described in the documentation.