### PR TITLE
[fix] chrome dev tools errors

### DIFF
--- a/client/components/Contact.js
+++ b/client/components/Contact.js
@@ -1,17 +1,22 @@
 import React from 'react'
 
 import Form from '~/client/components/Form'
+import Link from '~/client/components/Link'
 
 import { Header } from '~/client/styles'
 import { Disclaimer, StyledContact } from '~/client/styles/contact'
+
+const GOOGLE_PRIVACY_POLICY = 'https://policies.google.com/privacy?hl=en-US'
+const GOOGLE_TERMS_OF_SERVICE = 'https://policies.google.com/terms?hl=en-US'
 
 const Contact = () => (
   <StyledContact>
     <Header fontSize='45'>Let&apos;s Work Together!</Header>
     <Form />
     <Disclaimer>
-      This site is protected by reCAPTCHA and the Google Privacy Policy and
-      Terms of Service apply.
+      This site is protected by reCAPTCHA and the Google{' '}
+      <Link href={GOOGLE_PRIVACY_POLICY}>Privacy Policy</Link> and{' '}
+      <Link href={GOOGLE_TERMS_OF_SERVICE}>Terms of Service</Link> apply.
     </Disclaimer>
   </StyledContact>
 )

--- a/client/components/Form.js
+++ b/client/components/Form.js
@@ -90,6 +90,7 @@ const Form = () => {
           name,
           placeholder,
           value: value || '',
+          'aria-describedby': `required-${name}`,
           onChange: handleChange(name.toLowerCase()),
         }
 
@@ -98,13 +99,16 @@ const Form = () => {
             <Asterisk />
             {name.charAt(0).toUpperCase() + name.slice(1)}
             {name !== 'message' ? (
-              <Input type={type} required {...inputProps} />
+              <Input type={type} autoComplete={name} required {...inputProps} />
             ) : (
               <TextArea maxLength={1500} rows={5} required {...inputProps} />
             )}
           </label>
         )
       })}
+      <span style={{ fontSize: '10pt', paddingBottom: '20px' }}>
+        <Asterisk /> Required field
+      </span>
       <Submit onClick={verifyHumanity} />
     </StyledForm>
   )

--- a/client/styles/contact.js
+++ b/client/styles/contact.js
@@ -33,7 +33,7 @@ export const StyledForm = styled.form`
   width: 50%;
 `
 
-export const Asterisk = styled.label`
+export const Asterisk = styled.span`
   :after {
     color: red;
     content: '* ';

--- a/public/index.html
+++ b/public/index.html
@@ -1,14 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-113073503-1"></script>
-    <script async>
+    <!-- Google tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-QKV611NFZ6"></script>
+    <script>
       window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
+      function gtag() { dataLayer.push(arguments); }
       gtag('js', new Date());
 
-      gtag('config', 'UA-113073503-1');
+      // Not trying to track visitor behavior outside my website
+      // https://developers.google.com/analytics/devguides/collection/gtagjs/cookies-user-id#cookie_flags
+      gtag('set', {
+        'cookie_flags': 'SameSite=Strict;'
+      });
+
+      gtag('config', 'G-QKV611NFZ6');
     </script>
 
     <!--PWA-->


### PR DESCRIPTION
### 🎯  Motivation

I was seeing some Chrome dev tools errors that were distracting me. These were the errors (or notices):

1. No label associated with a form field (for each form field)
2. Indicate whether to send a cookie in a cross-site request by specifying its `SameSite` attribute
3. Audit usage of `navigator.userAgent`, `navigator.appVersion`, and `navigator.platform`

I couldn't resolve the third issue because those are from dependencies within the app, so I have no control over them. I invoke `navigator` for the purposes of the service worker, but not the properties meant to be audited.

For the second, it seems the remaining issues are also from dependencies. I've added a `SameSite` attribute to my Google analytics script to avoid cookies and have also configured within GA to have sessions expire at 0 (upon closing the browser / leaving the page). I'm not looking to track people in any capacity and wanted to be sure that I wasn't.

The first issue wasn't as obvious to me at first. I tried passing in `htmlFor` and `id` props to each `label` and `input`, respectively, but that didn't help. It wasn't until I realized that I was essentially creating two nested labels by having `<Asterisk />` alongside the official `label`. In order to reuse this component for a description of what the asterisk means, I converted it to a `styled.span` component. (Otherwise, I could have removed the `label` and used `<Asterisk {...labelProps} />` instead.) That resolved the issue!

There was actually a fourth, but it was simple: add autocomplete where necessary (for name and email inputs).

### ✅ What's Changed

- Adds links to Google's privacy policy and terms of service within `<Disclaimer />`
  - A bit more accessible
- Resolves an error that was appearing in Chrome dev tools because of `<Asterisk />` 
  - Converts the styled component to a `span` instead of a `label`
- Includes `autocomplete` prop on `<Input />`s
- Shows `<Asterisk />` indicates a required field
- Refreshes Google analytics and avoids tracking