### PR TITLE
chore: use non-default exports for emailjs and styled-components

### DIFF
--- a/client/components/About.js
+++ b/client/components/About.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { NavLink } from 'react-router-dom'
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 
 import Button from '~/client/components/Button'
 import { Header } from '~/client/styles'

--- a/client/components/Articles.js
+++ b/client/components/Articles.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 
 import { useFetchArticlesQuery } from '~/api/index'
 

--- a/client/components/Footer.js
+++ b/client/components/Footer.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { brands, solid } from '@fortawesome/fontawesome-svg-core/import.macro'

--- a/client/components/Form.js
+++ b/client/components/Form.js
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useState } from 'react'
 
-import emailjs from '@emailjs/browser'
+import { send } from '@emailjs/browser'
 import { useGoogleReCaptcha } from 'react-google-recaptcha-v3'
 import toast, { Toaster } from 'react-hot-toast'
 
@@ -78,8 +78,7 @@ const Form = () => {
       limitRate: { throttle: 10000 }, // 10s
     }
 
-    emailjs
-      .send(serviceId, templateId, emailTemplate, emailJsOptions)
+    send(serviceId, templateId, emailTemplate, emailJsOptions)
       .then(() => toast.success(`${state.name}, your email has been sent!`))
       .catch(err => toast.error(err.text))
       .finally(() => setState(initialState))

--- a/client/components/Hamburger.jsx
+++ b/client/components/Hamburger.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 
 import { NavLink } from 'react-router-dom'
 import { Sling } from 'hamburger-react'
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 
 const MenuList = styled.ul`
   list-style: none;

--- a/client/components/Home.js
+++ b/client/components/Home.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 
 import { NavLink } from 'react-router-dom'
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 import TextTransition, { presets } from 'react-text-transition'
 
 import Button from '~/client/components/Button'

--- a/client/components/Loading.jsx
+++ b/client/components/Loading.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { InfinitySpin } from 'react-loader-spinner'
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 
 const StyledLoading = styled.div`
   display: flex;

--- a/client/components/Navbar.js
+++ b/client/components/Navbar.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 import { NavLink, Outlet } from 'react-router-dom'
 
 import Hamburger from '~/client/components/Hamburger'

--- a/client/styles/button.js
+++ b/client/styles/button.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 
 export const StyledButton = styled.button`
   flex: 1 1 auto;

--- a/client/styles/contact.js
+++ b/client/styles/contact.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components'
+import { css, styled } from 'styled-components'
 
 export const StyledContact = styled.div`
   display: flex;

--- a/client/styles/index.js
+++ b/client/styles/index.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 
 export const Header = styled.h1`
   font-size: ${props => props.fontSize}pt;

--- a/client/styles/work.js
+++ b/client/styles/work.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 
 export const ProjectStyle = styled.div`
   align-items: center;


### PR DESCRIPTION
While updating some my `eslint` import sorting configuration, I was seeing two `eslint` errors:

1. [no-named-as-default-member]
2. [no-named-as-default]

The first was resolved by simply importing `send` from `@emailjs/browser` instead of `emailjs` as a default export. The second was by importing `styled` as a named export from `styled-components` instead of as a default export.

[no-named-as-default-member]:
  https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default-member.md
[no-named-as-default]:
  https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default.md