### PR TITLE
refactor: use automatic jsx runtime

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -8,7 +8,7 @@ const plugins = [
 const babel = {
   presets: [
     ['@babel/preset-env', { modules: false, forceAllTransforms: true }],
-    '@babel/preset-react',
+    ['@babel/preset-react', { runtime: 'automatic' }],
   ],
   plugins: plugins.filter(Boolean),
 }

--- a/client/App.jsx
+++ b/client/App.jsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense } from 'react'
+import { lazy, Suspense } from 'react'
 import { createBrowserRouter } from 'react-router'
 import { RouterProvider } from 'react-router/dom'
 

--- a/client/components/About.js
+++ b/client/components/About.js
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { NavLink } from 'react-router'
 import { styled } from 'styled-components'
 

--- a/client/components/Articles.js
+++ b/client/components/Articles.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { styled } from 'styled-components'
 
 import { useFetchArticlesQuery } from '~/api/index'

--- a/client/components/Button.jsx
+++ b/client/components/Button.jsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import Link from '~/client/components/Link'
 
 import {

--- a/client/components/Contact.js
+++ b/client/components/Contact.js
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import Form from '~/client/components/Form'
 import Link from '~/client/components/Link'
 

--- a/client/components/Footer.js
+++ b/client/components/Footer.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { styled } from 'styled-components'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'

--- a/client/components/Form.js
+++ b/client/components/Form.js
@@ -1,6 +1,6 @@
 /* eslint no-undef: 0 */
 
-import React, { useCallback, useState } from 'react'
+import { useCallback, useState } from 'react'
 
 import { send } from '@emailjs/browser'
 import { useGoogleReCaptcha } from 'react-google-recaptcha-v3'

--- a/client/components/Hamburger.jsx
+++ b/client/components/Hamburger.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 import { NavLink } from 'react-router'
 import { Sling } from 'hamburger-react'

--- a/client/components/Home.js
+++ b/client/components/Home.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { NavLink } from 'react-router'
 import { styled } from 'styled-components'

--- a/client/components/Link.jsx
+++ b/client/components/Link.jsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const Link = props => (
   <a rel='noopener' target='_blank' {...props}>
     {props.children}

--- a/client/components/Loading.jsx
+++ b/client/components/Loading.jsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { InfinitySpin } from 'react-loader-spinner'
 import { styled } from 'styled-components'
 

--- a/client/components/Navbar.js
+++ b/client/components/Navbar.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { styled } from 'styled-components'
 import { NavLink, Outlet } from 'react-router'
 

--- a/client/components/Work.js
+++ b/client/components/Work.js
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { useFetchProjectsQuery } from '~/api/index'
 
 import Link from '~/client/components/Link'

--- a/main.js
+++ b/main.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { createRoot } from 'react-dom/client'
 
 import { ApiProvider } from '@reduxjs/toolkit/query/react'


### PR DESCRIPTION
### 🎯 Motivation

As of React 17, the React maintainers introduced a new JSX runtime. With this new runtime, the explicit import of `React` is no longer necessary.

### ✅ What's Changed

- Update `babel.config.js` to use the automatic JSX runtime
- Delete all explicit `React` imports, such as `import React from 'react'`

### 🧪 Testing

I tested on the browser to ensure everything still rendered as expected as well as ran `npm run lint` to ensure no errors cropped up.