### PR TITLE
refactor: use destructured array for named items, sort import

### DIFF
--- a/client/components/Footer.js
+++ b/client/components/Footer.js
@@ -2,8 +2,8 @@ import { styled } from 'styled-components'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
-  faLinkedin,
   faGithub,
+  faLinkedin,
   faMedium,
   faStackOverflow,
 } from '@fortawesome/free-brands-svg-icons'
@@ -48,17 +48,17 @@ const Footer = () => (
       &copy; {`${new Date().getFullYear()} Eleni Konior`}
     </span>
     <div>
-      {SOCIAL_LINKS.map(link => (
+      {SOCIAL_LINKS.map(([href, icon, color]) => (
         <Icon
-          key={link[0]}
-          href={link[0]}
-          rel='noopener'
+          key={href}
+          href={href}
+          rel='noopener noreferrer nofollow'
           target='_blank'
           tabIndex='0'
           role='presentation'
-          color={link[2]}
+          color={color}
         >
-          <FontAwesomeIcon icon={link[1]} />
+          <FontAwesomeIcon icon={icon} />
         </Icon>
       ))}
     </div>


### PR DESCRIPTION
### 🎯 Motivation

While working on #206, I saw that an import was out of alphabetical order in `client/components/Footer.js`. Further, it's been bothering me that I'm using the indices for the icon links in the footer as opposed to destructuring them to named items. The named items feels a bit cleaner / more obvious without having to go back up to the definition.

### ✅ What's Changed

- Sort `faGithub` to top of imports from `@fortawesome/free-brands-svg-icons`
- Use destructured items for footer links mapping
- 🚗 Drive-by: Add `noreferrer nofollow` to `Icon.rel` prop since that's more secure for links that leave your website