### PR TITLE
chore(deps): upgrade to React v19

### DIFF
--- a/client/components/Home.js
+++ b/client/components/Home.js
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react'
 
+import { animated, useTransition } from '@react-spring/web'
 import { NavLink } from 'react-router'
 import { styled } from 'styled-components'
-import TextTransition, { presets } from 'react-text-transition'
 
 import Button from '~/client/components/Button'
 
@@ -20,7 +20,9 @@ const Me = styled.div`
   }
 `
 
-const Carousel = styled(TextTransition)`
+const Carousel = styled(animated.div)`
+  display: inline-flex;
+  white-space: nowrap;
   font-weight: 600;
   color: #e0bf9f;
 `
@@ -67,13 +69,23 @@ const Home = () => {
     return () => clearTimeout(intervalId)
   }, [])
 
+  const transitions = useTransition(ME[idx % ME.length], {
+    enter: { opacity: 1, transform: 'translateY(0%)' },
+    from: { opacity: 0, transform: 'translateY(100%)' },
+    leave: {
+      opacity: 0,
+      transform: 'translateY(-100%)',
+      position: 'absolute',
+    },
+  })
+
   return (
     <Me>
       <span>
         I am{' '}
-        <Carousel direction='up' springConfig={presets.gentle} inline>
-          {ME[idx % ME.length]}
-        </Carousel>
+        {transitions((style, item) => (
+          <Carousel style={style}>{item}</Carousel>
+        ))}
       </span>
       <Description>
         After graduating from NYU with a B.A. in Economics, I decided to tap

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -59,7 +59,6 @@ export default [
       ],
       'react/display-name': 0,
       'react/prop-types': 0,
-      'react/no-string-refs': 0,
       'react/no-direct-mutation-state': 0,
       'react/require-render-return': 0,
       'react/jsx-no-undef': 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,17 +14,17 @@
         "@fortawesome/free-brands-svg-icons": "^6.7.1",
         "@fortawesome/free-solid-svg-icons": "^6.7.1",
         "@fortawesome/react-fontawesome": "^0.2.2",
+        "@react-spring/web": "^9.7.5",
         "@reduxjs/toolkit": "^2.4.0",
         "firebase": "^11.0.2",
         "hamburger-react": "^2.5.1",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "react-google-recaptcha-v3": "^1.10.1",
         "react-hot-toast": "^2.4.1",
         "react-loader-spinner": "^6.1.6",
         "react-redux": "^9.1.2",
         "react-router": "^7.0.2",
-        "react-text-transition": "^3.1.0",
         "styled-components": "^6.1.13"
       },
       "devDependencies": {
@@ -54,7 +54,7 @@
         "lint-staged": "^15.2.10",
         "prettier": "^3.4.2",
         "react-async-script": "^1.2.0",
-        "react-refresh": "^0.14.2",
+        "react-refresh": "^0.16.0",
         "strip-ansi": "^7.1.0",
         "style-loader": "^4.0.0",
         "through2": "^4.0.2",
@@ -14599,13 +14599,10 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14625,16 +14622,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
+      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.25.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.0.0"
       }
     },
     "node_modules/react-google-recaptcha-v3": {
@@ -14713,9 +14709,9 @@
       }
     },
     "node_modules/react-refresh": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
-      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.16.0.tgz",
+      "integrity": "sha512-FPvF2XxTSikpJxcr+bHut2H4gJ17+18Uy20D5/F+SKzFap62R3cM5wH6b8WN3LyGSYeQilLEcJcR1fjBSI2S1A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14753,18 +14749,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/react-text-transition": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/react-text-transition/-/react-text-transition-3.1.0.tgz",
-      "integrity": "sha512-NtXEVAXvSh78+8JAnrVjpbftzD4kPowacv4GB2Nyq9C/8ko6fSm6M/XvKWQLCaZi68i9F28b++Sp8uVThlzLyg==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/web": "^9.7.2"
-      },
-      "peerDependencies": {
-        "react": ">=18.0.0"
       }
     },
     "node_modules/readable-stream": {
@@ -15306,13 +15290,10 @@
       "license": "MIT"
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,26 @@
       "git add --"
     ]
   },
+  "overrides": {
+    "@react-spring/web": {
+      "react": "^19",
+      "react-dom": "^19"
+    },
+    "@reduxjs/toolkit": {
+      "react": "^19"
+    },
+    "hamburger-react": {
+      "react": "^19"
+    },
+    "react-google-recaptcha-v3": {
+      "react": "^19",
+      "react-dom": "^19"
+    },
+    "react-loader-spinner": {
+      "react": "^19",
+      "react-dom": "^19"
+    }
+  },
   "devDependencies": {
     "@babel/core": "^7.26.0",
     "@babel/plugin-transform-runtime": "^7.25.9",
@@ -69,7 +89,7 @@
     "lint-staged": "^15.2.10",
     "prettier": "^3.4.2",
     "react-async-script": "^1.2.0",
-    "react-refresh": "^0.14.2",
+    "react-refresh": "^0.16.0",
     "strip-ansi": "^7.1.0",
     "style-loader": "^4.0.0",
     "through2": "^4.0.2",
@@ -85,17 +105,17 @@
     "@fortawesome/free-brands-svg-icons": "^6.7.1",
     "@fortawesome/free-solid-svg-icons": "^6.7.1",
     "@fortawesome/react-fontawesome": "^0.2.2",
+    "@react-spring/web": "^9.7.5",
     "@reduxjs/toolkit": "^2.4.0",
     "firebase": "^11.0.2",
     "hamburger-react": "^2.5.1",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "react-google-recaptcha-v3": "^1.10.1",
     "react-hot-toast": "^2.4.1",
     "react-loader-spinner": "^6.1.6",
     "react-redux": "^9.1.2",
     "react-router": "^7.0.2",
-    "react-text-transition": "^3.1.0",
     "styled-components": "^6.1.13"
   }
 }


### PR DESCRIPTION
### 🎯 Motivation

When running `npm outdated` I saw three outdated packages that required major upgrades:
1. `react`
2. `react-dom`
3. `react-refresh`

This is because last week React v19 was released! There were minimal changes required for the app to work with the latest React version: one, expectedly, was to override some packages that still haven't included v19 as a dependency; the other was unexpected and required changing some source code. When I booted up the app in dev I saw that the homepage wouldn't render (`/home`) due to `react-text-transition`. This package is used to make some descriptions of me randomly rotate and provide some dynamic elements to the page, but it hadn't been updated in two years, and it used `@react-spring/web` as a dependency anyway. So, I am now using the same package, which required incorporating some logic that was hidden from the user of `react-text-transition` per their docs.

### ✅  What's changed

- Uninstall `react-text-transtition`; install `@react-spring/web`
  - Use `useTransition` API and update some CSS
  - Have `Carousel` be a styled `animated.div` as well
- Delete unnecessary `eslint` rule for `react/no-string-refs` since with v19 string refs are no longer allowed
- Install latest versions of above packages
- Override `react` and `react-dom` where required for v19