### PR TITLE
refactor: prefer non-default imports

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,7 +1,7 @@
 import { collection, getDocs } from 'firebase/firestore'
 import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react'
 
-import db from '~/db/firebase'
+import { db } from '~/db/firebase'
 
 const fetchData = async path => {
   try {

--- a/client/App.jsx
+++ b/client/App.jsx
@@ -2,15 +2,25 @@ import { lazy, Suspense } from 'react'
 import { createBrowserRouter } from 'react-router'
 import { RouterProvider } from 'react-router/dom'
 
-import About from '~/client/components/About'
-import Footer from '~/client/components/Footer'
-import Home from '~/client/components/Home'
-import Loading from '~/client/components/Loading'
-import Navbar from '~/client/components/Navbar'
+import { About } from '~/client/components/About'
+import { Footer } from '~/client/components/Footer'
+import { Home } from '~/client/components/Home'
+import { Loading } from '~/client/components/Loading'
+import { Navbar } from '~/client/components/Navbar'
 
-const Articles = lazy(() => import('~/client/components/Articles'))
-const Contact = lazy(() => import('~/client/components/Contact'))
-const Work = lazy(() => import('~/client/components/Work'))
+const Articles = lazy(() =>
+  import('~/client/components/Articles').then(module => ({
+    default: module.Articles,
+  }))
+)
+const Contact = lazy(() =>
+  import('~/client/components/Contact').then(module => ({
+    default: module.Contact,
+  }))
+)
+const Work = lazy(() =>
+  import('~/client/components/Work').then(module => ({ default: module.Work }))
+)
 
 const router = createBrowserRouter([
   {
@@ -26,11 +36,9 @@ const router = createBrowserRouter([
   },
 ])
 
-const App = () => (
+export const App = () => (
   <Suspense fallback={<Loading />}>
     <RouterProvider router={router} />
     <Footer />
   </Suspense>
 )
-
-export default App

--- a/client/components/About.js
+++ b/client/components/About.js
@@ -1,7 +1,7 @@
 import { NavLink } from 'react-router'
 import { styled } from 'styled-components'
 
-import Button from '~/client/components/Button'
+import { Button } from '~/client/components/Button'
 import { Header } from '~/client/styles'
 
 const StyledAbout = styled.div`
@@ -11,7 +11,7 @@ const StyledAbout = styled.div`
   width: 65%;
 `
 
-const About = () => (
+export const About = () => (
   <StyledAbout>
     <Header fontSize='30'>Creating useful and engaging software</Header>
     <div style={{ fontSize: '14pt' }}>
@@ -43,5 +43,3 @@ const About = () => (
     </NavLink>
   </StyledAbout>
 )
-
-export default About

--- a/client/components/Articles.js
+++ b/client/components/Articles.js
@@ -2,9 +2,9 @@ import { styled } from 'styled-components'
 
 import { useFetchArticlesQuery } from '~/api/index'
 
-import Button from '~/client/components/Button'
-import Link from '~/client/components/Link'
-import Loading from '~/client/components/Loading'
+import { Button } from '~/client/components/Button'
+import { Link } from '~/client/components/Link'
+import { Loading } from '~/client/components/Loading'
 
 const StyledHr = styled.hr`
   border-color: #e0bf9f;
@@ -23,7 +23,7 @@ const Article = styled.div`
   }
 `
 
-const Articles = () => {
+export const Articles = () => {
   const { data: articles } = useFetchArticlesQuery()
 
   return (
@@ -49,5 +49,3 @@ const Articles = () => {
     </>
   )
 }
-
-export default Articles

--- a/client/components/Button.jsx
+++ b/client/components/Button.jsx
@@ -1,4 +1,4 @@
-import Link from '~/client/components/Link'
+import { Link } from '~/client/components/Link'
 
 import {
   ProjectLinkButton,
@@ -6,7 +6,7 @@ import {
   SubmitButton,
 } from '~/client/styles/button'
 
-const Button = ({ text }) => <StyledButton>{text}</StyledButton>
+export const Button = ({ text }) => <StyledButton>{text}</StyledButton>
 export const Submit = props => (
   <SubmitButton type='submit' {...props}>
     Submit
@@ -25,5 +25,3 @@ export const ProjectLink = ({ link }) => (
     <ProjectLinkButton>{determineProjectButtonText(link)}</ProjectLinkButton>
   </Link>
 )
-
-export default Button

--- a/client/components/Contact.js
+++ b/client/components/Contact.js
@@ -1,5 +1,5 @@
-import Form from '~/client/components/Form'
-import Link from '~/client/components/Link'
+import { Form } from '~/client/components/Form'
+import { Link } from '~/client/components/Link'
 
 import { Header } from '~/client/styles'
 import { Disclaimer, StyledContact } from '~/client/styles/contact'
@@ -7,7 +7,7 @@ import { Disclaimer, StyledContact } from '~/client/styles/contact'
 const GOOGLE_PRIVACY_POLICY = 'https://policies.google.com/privacy?hl=en-US'
 const GOOGLE_TERMS_OF_SERVICE = 'https://policies.google.com/terms?hl=en-US'
 
-const Contact = () => (
+export const Contact = () => (
   <StyledContact>
     <Header fontSize='45'>Let&apos;s Work Together!</Header>
     <Form />
@@ -18,5 +18,3 @@ const Contact = () => (
     </Disclaimer>
   </StyledContact>
 )
-
-export default Contact

--- a/client/components/Footer.js
+++ b/client/components/Footer.js
@@ -42,7 +42,7 @@ const Icon = styled.a`
   }
 `
 
-const Footer = () => (
+export const Footer = () => (
   <StyledFooter role='contentinfo'>
     <span style={{ color: '#858686' }}>
       &copy; {`${new Date().getFullYear()} Eleni Konior`}
@@ -64,5 +64,3 @@ const Footer = () => (
     </div>
   </StyledFooter>
 )
-
-export default Footer

--- a/client/components/Form.js
+++ b/client/components/Form.js
@@ -36,7 +36,7 @@ const getInputs = ({ name, email, message }) => [
   },
 ]
 
-const Form = () => {
+export const Form = () => {
   const { executeRecaptcha } = useGoogleReCaptcha()
   const initialState = {
     name: '',
@@ -116,5 +116,3 @@ const Form = () => {
     </StyledForm>
   )
 }
-
-export default Form

--- a/client/components/Hamburger.jsx
+++ b/client/components/Hamburger.jsx
@@ -51,7 +51,7 @@ const StyledNavLink = styled(NavLink)`
 
 const LINKS = ['Home', 'About', 'Work', 'Articles', 'Contact']
 
-const Hamburger = () => {
+export const Hamburger = () => {
   const [open, setOpen] = useState(false)
   const toggleMenu = () => setOpen(!open)
 
@@ -81,5 +81,3 @@ const Hamburger = () => {
     </>
   )
 }
-
-export default Hamburger

--- a/client/components/Home.js
+++ b/client/components/Home.js
@@ -4,7 +4,7 @@ import { animated, useTransition } from '@react-spring/web'
 import { NavLink } from 'react-router'
 import { styled } from 'styled-components'
 
-import Button from '~/client/components/Button'
+import { Button } from '~/client/components/Button'
 
 const Me = styled.div`
   display: flex;
@@ -58,7 +58,7 @@ const ME = [
   'a STEMinist 👩🏻‍🔬',
 ]
 
-const Home = () => {
+export const Home = () => {
   const [idx, setIdx] = useState(0)
 
   useEffect(() => {
@@ -103,5 +103,3 @@ const Home = () => {
     </Me>
   )
 }
-
-export default Home

--- a/client/components/Link.jsx
+++ b/client/components/Link.jsx
@@ -1,7 +1,5 @@
-const Link = props => (
+export const Link = props => (
   <a rel='noopener' target='_blank' {...props}>
     {props.children}
   </a>
 )
-
-export default Link

--- a/client/components/Loading.jsx
+++ b/client/components/Loading.jsx
@@ -8,10 +8,8 @@ const StyledLoading = styled.div`
   justify-content: center;
 `
 
-const Loading = () => (
+export const Loading = () => (
   <StyledLoading>
     <InfinitySpin visible color='#e0bf9f' ariaLabel='infinity-spin-loading' />
   </StyledLoading>
 )
-
-export default Loading

--- a/client/components/Navbar.js
+++ b/client/components/Navbar.js
@@ -1,7 +1,7 @@
 import { styled } from 'styled-components'
 import { NavLink, Outlet } from 'react-router'
 
-import Hamburger from '~/client/components/Hamburger'
+import { Hamburger } from '~/client/components/Hamburger'
 
 const Nav = styled.nav`
   top: 0;
@@ -23,7 +23,7 @@ const Logo = styled.img`
   max-height: 30px;
 `
 
-const Navbar = () => (
+export const Navbar = () => (
   <>
     <Nav role='navigation'>
       <NavLink to='/'>
@@ -34,5 +34,3 @@ const Navbar = () => (
     <Outlet />
   </>
 )
-
-export default Navbar

--- a/client/components/Work.js
+++ b/client/components/Work.js
@@ -1,9 +1,9 @@
 import { useFetchProjectsQuery } from '~/api/index'
 
-import Link from '~/client/components/Link'
-import Loading from '~/client/components/Loading'
+import { Link } from '~/client/components/Link'
+import { Loading } from '~/client/components/Loading'
 import { ProjectLink } from '~/client/components/Button'
-import useExpansion from '~/client/hooks/useExpansion'
+import { useExpansion } from '~/client/hooks/useExpansion'
 
 import { ResumeButton } from '~/client/styles/button'
 import {
@@ -15,7 +15,7 @@ import {
   Tech,
 } from '~/client/styles/work'
 
-const Work = () => {
+export const Work = () => {
   const { toggle, isExpanded, expandedItem } = useExpansion()
   const { data: projects } = useFetchProjectsQuery()
 
@@ -48,5 +48,3 @@ const Work = () => {
     </>
   )
 }
-
-export default Work

--- a/client/hooks/useExpansion.js
+++ b/client/hooks/useExpansion.js
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react'
 
-const useExpansion = () => {
+export const useExpansion = () => {
   const [isExpanded, setIsExpanded] = useState(false)
   const [expandedItem, setExpandedItem] = useState('')
 
@@ -29,5 +29,3 @@ const useExpansion = () => {
 
   return { toggle, isExpanded, expandedItem }
 }
-
-export default useExpansion

--- a/client/styles/GlobalStyles.js
+++ b/client/styles/GlobalStyles.js
@@ -1,6 +1,6 @@
 import { createGlobalStyle } from 'styled-components'
 
-const GlobalStyle = createGlobalStyle`
+export const GlobalStyle = createGlobalStyle`
   body {
     background-color: rgba(0, 0, 0, 1);
     padding-bottom: 5%;
@@ -33,5 +33,3 @@ const GlobalStyle = createGlobalStyle`
     left: 0;
   }
 `
-
-export default GlobalStyle

--- a/db/firebase.js
+++ b/db/firebase.js
@@ -29,5 +29,4 @@ initializeAppCheck(fire, {
   isTokenAutoRefreshEnabled: true, // allow auto-refresh
 })
 
-const db = getFirestore(fire)
-export default db
+export const db = getFirestore(fire)

--- a/main.js
+++ b/main.js
@@ -4,8 +4,8 @@ import { ApiProvider } from '@reduxjs/toolkit/query/react'
 import { GoogleReCaptchaProvider } from 'react-google-recaptcha-v3'
 import { ThemeProvider } from 'styled-components'
 
-import App from '~/client/App'
-import GlobalStyle from '~/client/styles/GlobalStyles'
+import { App } from '~/client/App'
+import { GlobalStyle } from '~/client/styles/GlobalStyles'
 
 import { firebaseApi } from '~/api/index'
 


### PR DESCRIPTION
### 🎯 Motivation

Most of the files in this app define one component in each file, but regardless it takes extra lines to define a default export. The other option would be `export default () => /* component definition */`, which would take the name of the file as the name of the component. This app used to have that syntax, but it's not friendly to anyone looking to learn JavaScript. Thus, prefer non-default exports moving forward.

### ✅ What's changed

- Use named exports everywhere
- Add promise for `lazy` imports to grab the named export correctly