### PR TITLE
feat(form): auto-expand textarea

### DIFF
--- a/client/components/Form.js
+++ b/client/components/Form.js
@@ -63,6 +63,12 @@ export const Form = () => {
     })
   }
 
+  const handleTextAreaInput = evt => {
+    const textarea = evt.target
+    textarea.style.height = 'auto'
+    textarea.style.height = `${textarea.scrollHeight}px`
+  }
+
   const sendEmail = evt => {
     evt.preventDefault()
 
@@ -104,7 +110,13 @@ export const Form = () => {
             {name !== 'message' ? (
               <Input type={type} autoComplete={name} required {...inputProps} />
             ) : (
-              <TextArea maxLength={1500} rows={5} required {...inputProps} />
+              <TextArea
+                maxLength={1500}
+                rows={2}
+                onInput={handleTextAreaInput}
+                required
+                {...inputProps}
+              />
             )}
           </label>
         )

--- a/client/styles/contact.js
+++ b/client/styles/contact.js
@@ -18,10 +18,10 @@ const inputAndTextAreaStyles = css`
   margin-bottom: 10%;
   background: transparent;
   border: transparent;
-  border-bottom: 1.5px solid gray;
+  border-bottom: thin solid gray;
 
   &:focus {
-    border-bottom: 1.5px solid #e0bf9f;
+    border-bottom: thin solid #e0bf9f;
     transition: all 0.25s ease-in-out;
   }
 `
@@ -46,8 +46,7 @@ export const Input = styled.input`
 `
 
 export const TextArea = styled.textarea`
-  resize: vertical;
-  min-height: 65px;
+  resize: none;
   max-height: 300px;
   ${inputAndTextAreaStyles}
 `


### PR DESCRIPTION
previously the form textarea rendered with a lot of rows and it looked slightly off. now the textarea renders with 2 rows and will autoscale in height up to a max limit while the user is typing.]

the change also uses `thin` instead of `1.5px` for the `border-bottom` CSS property since WebStorm was noting that float pixels might render inconsistently across browsers.