### PR TITLE
feat(form): disable inputs and textarea, show submitting while sending email

### DIFF
--- a/client/components/Button.jsx
+++ b/client/components/Button.jsx
@@ -9,7 +9,7 @@ import {
 export const Button = ({ text }) => <StyledButton>{text}</StyledButton>
 export const Submit = props => (
   <SubmitButton type='submit' {...props}>
-    Submit
+    {props.isSubmitting ? 'Submitting...' : 'Submit'}
   </SubmitButton>
 )
 

--- a/client/components/Form.js
+++ b/client/components/Form.js
@@ -45,6 +45,7 @@ export const Form = () => {
     token: '',
   }
   const [state, setState] = useState(initialState)
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
   const verifyHumanity = useCallback(async () => {
     if (!executeRecaptcha) {
@@ -84,10 +85,15 @@ export const Form = () => {
       limitRate: { throttle: 10000 }, // 10s
     }
 
+    setIsSubmitting(true)
+
     send(serviceId, templateId, emailTemplate, emailJsOptions)
       .then(() => toast.success(`${state.name}, your email has been sent!`))
-      .catch(err => toast.error(err.text))
-      .finally(() => setState(initialState))
+      .catch(err => toast.error(err.text || 'Failed to send email'))
+      .finally(() => {
+        setIsSubmitting(false)
+        setState(initialState)
+      })
   }
 
   const inputs = getInputs(state)
@@ -101,6 +107,7 @@ export const Form = () => {
           value: value || '',
           'aria-describedby': `required-${name}`,
           onChange: handleChange(name.toLowerCase()),
+          disabled: isSubmitting,
         }
 
         return (
@@ -124,7 +131,7 @@ export const Form = () => {
       <span style={{ fontSize: '10pt', paddingBottom: '20px' }}>
         <Asterisk /> Required field
       </span>
-      <Submit onClick={verifyHumanity} />
+      <Submit onClick={verifyHumanity} isSubmitting={isSubmitting} />
     </StyledForm>
   )
 }


### PR DESCRIPTION
previously when a user would send a message by hitting the submit button, the form state would immediately reset. it can take some seconds for the message to successfully be sent, so the behavior wasn't a great user experience because the result was unknown until the toast appeared. now, the submit button will show it is submitting while the email is being sent as well as disable the input and textarea fields until there is a success or failure.

it also adds a default error message in the event the email cannot be sent and `err.text` is falsey