### PR TITLE
fix(SubmitButton): avoid passing isSubmitting prop to styled button

### DIFF
--- a/client/components/Button.jsx
+++ b/client/components/Button.jsx
@@ -1,17 +1,8 @@
 import { Link } from '~/client/components/Link'
 
-import {
-  ProjectLinkButton,
-  StyledButton,
-  SubmitButton,
-} from '~/client/styles/button'
+import { ProjectLinkButton, StyledButton } from '~/client/styles/button'
 
 export const Button = ({ text }) => <StyledButton>{text}</StyledButton>
-export const Submit = props => (
-  <SubmitButton type='submit' {...props}>
-    {props.isSubmitting ? 'Submitting...' : 'Submit'}
-  </SubmitButton>
-)
 
 const determineProjectButtonText = link =>
   link.includes('github')

--- a/client/components/Form.js
+++ b/client/components/Form.js
@@ -6,7 +6,7 @@ import { send } from '@emailjs/browser'
 import { useGoogleReCaptcha } from 'react-google-recaptcha-v3'
 import toast, { Toaster } from 'react-hot-toast'
 
-import { Submit } from '~/client/components/Button'
+import { SubmitButton } from '~/client/styles/button.js'
 import { Asterisk, Input, StyledForm, TextArea } from '~/client/styles/contact'
 
 // emailJS IDs
@@ -131,7 +131,9 @@ export const Form = () => {
       <span style={{ fontSize: '10pt', paddingBottom: '20px' }}>
         <Asterisk /> Required field
       </span>
-      <Submit onClick={verifyHumanity} isSubmitting={isSubmitting} />
+      <SubmitButton type='submit' onClick={verifyHumanity}>
+        {isSubmitting ? 'Submitting...' : 'Submit'}
+      </SubmitButton>
     </StyledForm>
   )
 }


### PR DESCRIPTION
previously we passed a new prop `isSubmitting` to the submit button, but the way that was laid out was leveraging props for styled-components to render the type of button it is (in this case, `submit`). this produced a React error that the `isSubmitting` prop should be lowercase if we wanted it to appear in the component tree. that was unnecessary, and since this is the only submittable button, this change moves the button to the `<Form />` component. it leverages the `isSubmitting` state constant inline instead.