### PR TITLE
feat(link): add noreferrer to a tag rel

### DIFF
--- a/client/components/Link.jsx
+++ b/client/components/Link.jsx
@@ -1,5 +1,5 @@
 export const Link = props => (
-  <a rel='noopener' target='_blank' {...props}>
+  <a rel='noopener noreferrer' target='_blank' {...props}>
     {props.children}
   </a>
 )


### PR DESCRIPTION
while some browsers have this as the default now for `target='_blank'`, it doesn't hurt to add it explicitly. now all `a` tags have `rel='noopener noreferrer'`