### PR TITLE
feat(ErrorBoundary): add error boundary to app

### DIFF
--- a/client/components/ErrorFallback.jsx
+++ b/client/components/ErrorFallback.jsx
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from 'react'
+import { useLocation } from 'react-router'
+import { styled } from 'styled-components'
+
+import { CenterStyledButton } from '~/client/styles/button'
+
+const StyledError = styled.div`
+  display: flex;
+  flex-flow: column wrap;
+  align-items: center;
+`
+
+export const ErrorFallback = ({ error, resetErrorBoundary }) => {
+  const location = useLocation()
+  const navigated = useRef(false)
+
+  useEffect(() => {
+    navigated.current ? resetErrorBoundary() : (navigated.current = true)
+  }, [location, resetErrorBoundary])
+
+  return (
+    <StyledError>
+      <h2>Uh oh! Something went wrong 🫠</h2>
+      <pre style={{ color: 'red' }}>Error: {error.message}</pre>
+      <p>Please click the button to try again or navigate to another route.</p>
+      <CenterStyledButton onClick={resetErrorBoundary}>
+        Try again
+      </CenterStyledButton>
+    </StyledError>
+  )
+}

--- a/client/components/Navbar.js
+++ b/client/components/Navbar.js
@@ -1,6 +1,8 @@
-import { styled } from 'styled-components'
+import { ErrorBoundary } from 'react-error-boundary'
 import { NavLink, Outlet } from 'react-router'
+import { styled } from 'styled-components'
 
+import { ErrorFallback } from '~/client/components/ErrorFallback'
 import { Hamburger } from '~/client/components/Hamburger'
 
 const Nav = styled.nav`
@@ -31,6 +33,8 @@ export const Navbar = () => (
       </NavLink>
       <Hamburger />
     </Nav>
-    <Outlet />
+    <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <Outlet />
+    </ErrorBoundary>
   </>
 )

--- a/client/components/Work.js
+++ b/client/components/Work.js
@@ -4,7 +4,7 @@ import { Link } from '~/client/components/Link'
 import { Loading } from '~/client/components/Loading'
 import { useExpansion } from '~/client/hooks/useExpansion'
 
-import { ProjectLinkButton, ResumeButton } from '~/client/styles/button'
+import { CenterStyledButton, ProjectLinkButton } from '~/client/styles/button'
 import {
   Description,
   Detail,
@@ -27,9 +27,9 @@ export const Work = () => {
 
   return (
     <>
-      <ResumeButton>
+      <CenterStyledButton>
         <Link href='/assets/EleniArvanitisKoniorResume.pdf'>View Resume</Link>
-      </ResumeButton>
+      </CenterStyledButton>
       {!projects && <Loading />}
       {projects &&
         projects.map(({ name, role, description, technologies, links }) => (

--- a/client/styles/button.js
+++ b/client/styles/button.js
@@ -45,7 +45,7 @@ export const StyledButton = styled.button`
   }
 `
 
-export const ResumeButton = styled(StyledButton)`
+export const CenterStyledButton = styled(StyledButton)`
   display: flex;
   margin: 10px auto;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "hamburger-react": "^2.5.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-error-boundary": "^5.0.0",
         "react-google-recaptcha-v3": "^1.10.1",
         "react-hot-toast": "^2.4.1",
         "react-loader-spinner": "^6.1.6",
@@ -1669,7 +1670,6 @@
       "version": "7.26.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
       "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -14586,6 +14586,18 @@
         "react": "^19.0.0"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-5.0.0.tgz",
+      "integrity": "sha512-tnjAxG+IkpLephNcePNA7v6F/QpWLH8He65+DmedchDwg162JZqx4NmbXj0mlAYVVEd81OW7aFhmbsScYfiAFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-google-recaptcha-v3": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/react-google-recaptcha-v3/-/react-google-recaptcha-v3-1.10.1.tgz",
@@ -14847,7 +14859,6 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/regenerator-transform": {

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "hamburger-react": "^2.5.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-error-boundary": "^5.0.0",
     "react-google-recaptcha-v3": "^1.10.1",
     "react-hot-toast": "^2.4.1",
     "react-loader-spinner": "^6.1.6",


### PR DESCRIPTION
### 🎯 Motivation
After making some changes to the app's navigation buttons, I noticed upon loading the deployed app for the first time that an error occurred. It was hard to reproduce this error since it only appeared randomly a couple times even after unregistering the service worker and hard reloading. However, one theory is that lazy loading was not quite complete by the time the navigation button was clicked and the page attempted to render.

Thus, this commit adds an `ErrorBoundary` using `react-error-boundary` and a custom fallback component in `ErrorFallback` so that when issues occur the user can try to reload the page they're currently on. If the user does not click the try again button and navigates to a different route, the error context will also refresh.

I placed the `ErrorBoundary` logic in the `Navbar` component since that is the component that builds up the browser router in `App.jsx`. It was the only way to allow for an error boundary to work across all routes without putting the error boundary as a wrapper component in every element of said router or changing the `Navbar` to be part of an error boundary wrapper component. This also allows the navbar to continue loading in the app with the fallback component within it, instead of just the fallback component rendering without the navbar present (given a previous iteration).

### ✅ What's Changed
- Create `ErrorFallback` component
- Modify `Navbar` component to include the new `ErrorFallback` component, which wraps around `Outlet`
- Sort imports in `client/components/Navbar.js`
- Rename `ResumeButton` to `CenterStyledButton` since I wanted the try button to also be centered, and there was nothing else but styles that were specific to that button
- Install `react-error-boundary`

### 🔗 Links
- https://api.reactrouter.com/v7/functions/react_router.Outlet.html
- https://github.com/bvaughn/react-error-boundary?tab=readme-ov-file#react-error-boundary