### PR TITLE
refactor(firebase): create firebase-app directory and split up logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The frontend starts in [`main.js`]. The root of the React app is in [`App.jsx`].
 #### a word about ~
 
 The webpack config aliases `~` to mean "the root of the app". For example, you
-can `import db from '~/db/firebase'` anywhere in the app, without worrying about
-how many `..`s to have in the relative path.
+can `import { db } from '~/firebase-app'` anywhere in the app, without worrying
+about how many `..`s to have in the relative path.
 
 ### Fast Refreshing
 

--- a/api/index.js
+++ b/api/index.js
@@ -1,7 +1,7 @@
 import { collection, getDocs } from 'firebase/firestore'
 import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react'
 
-import { db } from '~/db/firebase'
+import { db } from '~/firebase-app'
 
 const fetchData = async path => {
   try {

--- a/firebase-app/app.js
+++ b/firebase-app/app.js
@@ -1,18 +1,8 @@
-/* eslint no-undef: 0, sort-imports: 0 */
-
 import { initializeApp } from 'firebase/app'
 import {
   initializeAppCheck,
   ReCaptchaEnterpriseProvider,
 } from 'firebase/app-check'
-import { getFirestore } from 'firebase/firestore'
-
-const fire = initializeApp({
-  apiKey: process.env.FIREBASE_API_KEY,
-  databaseURL: 'https://elenicodes.firebaseio.com',
-  projectId: 'elenicodes',
-  appId: process.env.FIREBASE_APP_ID,
-})
 
 self.FIREBASE_APPCHECK_DEBUG_TOKEN =
   process.env.NODE_ENV === 'development'
@@ -24,9 +14,14 @@ const recaptchaToken =
     ? self.FIREBASE_APPCHECK_DEBUG_TOKEN
     : process.env.ENTERPRISE_RECAPTCHA_SITE_KEY
 
-initializeAppCheck(fire, {
+export const app = initializeApp({
+  apiKey: process.env.FIREBASE_API_KEY,
+  databaseURL: 'https://elenicodes.firebaseio.com',
+  projectId: 'elenicodes',
+  appId: process.env.FIREBASE_APP_ID,
+})
+
+initializeAppCheck(app, {
   provider: new ReCaptchaEnterpriseProvider(recaptchaToken),
   isTokenAutoRefreshEnabled: true, // allow auto-refresh
 })
-
-export const db = getFirestore(fire)

--- a/firebase-app/db.js
+++ b/firebase-app/db.js
@@ -1,0 +1,5 @@
+import { getFirestore } from 'firebase/firestore'
+
+import { app } from '~/firebase-app/app'
+
+export const db = getFirestore(app)

--- a/firebase-app/index.js
+++ b/firebase-app/index.js
@@ -1,0 +1,2 @@
+export * from '~/firebase-app/app'
+export * from '~/firebase-app/db'


### PR DESCRIPTION
### 🎯 Motivation
I'm intending to add firebase crashlytics to the app, but right now all the firebase logic is commingled into one file with the app definition and the database instantiation in one file. Thus, this commit shifts things a bit so that the app and db logic are in their own files.

### ✅ What's Changed
- Refine example import in `README`
- Update `db` path in `api/index.js`
- Delete `eslint` ignore line in `firebase-app/app.js` since they no longer appear when running `npx eslint .`
- Move `app` instantiation to be beneath app check env logic
- Move db logic into `firebase-app/db.js`
- Use `index.js` to export all items from `firebase-app` directory without having to pass the explicit filenames