### PR TITLE
refactor(db): move fetchData into db module

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The frontend starts in [`main.js`]. The root of the React app is in [`App.jsx`].
 #### a word about ~
 
 The webpack config aliases `~` to mean "the root of the app". For example, you
-can `import { db } from '~/firebase-app'` anywhere in the app, without worrying
+can `import { firebaseApi } from '~/api'` anywhere in the app, without worrying
 about how many `..`s to have in the relative path.
 
 ### Fast Refreshing

--- a/api/index.js
+++ b/api/index.js
@@ -1,18 +1,6 @@
-import { collection, getDocs } from 'firebase/firestore'
 import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react'
 
-import { db } from '~/firebase-app'
-
-const fetchData = async path => {
-  try {
-    const querySnapshot = await getDocs(collection(db, path))
-    const data = querySnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }))
-
-    return { data }
-  } catch (error) {
-    return { error }
-  }
-}
+import { fetchData } from '~/firebase-app'
 
 export const firebaseApi = createApi({
   baseQuery: fakeBaseQuery(),

--- a/client/components/Articles.js
+++ b/client/components/Articles.js
@@ -1,6 +1,6 @@
 import { styled } from 'styled-components'
 
-import { useFetchArticlesQuery } from '~/api/index'
+import { useFetchArticlesQuery } from '~/api'
 
 import { Link } from '~/client/components/Link'
 import { Loading } from '~/client/components/Loading'

--- a/client/components/Work.js
+++ b/client/components/Work.js
@@ -1,4 +1,4 @@
-import { useFetchProjectsQuery } from '~/api/index'
+import { useFetchProjectsQuery } from '~/api'
 
 import { Link } from '~/client/components/Link'
 import { Loading } from '~/client/components/Loading'

--- a/firebase-app/db.js
+++ b/firebase-app/db.js
@@ -1,5 +1,16 @@
-import { getFirestore } from 'firebase/firestore'
+import { collection, getDocs, getFirestore } from 'firebase/firestore'
 
 import { app } from '~/firebase-app/app'
 
-export const db = getFirestore(app)
+const DB = getFirestore(app)
+
+export const fetchData = async path => {
+  try {
+    const querySnapshot = await getDocs(collection(DB, path))
+    const data = querySnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }))
+
+    return { data }
+  } catch (error) {
+    return { error }
+  }
+}

--- a/main.js
+++ b/main.js
@@ -7,7 +7,7 @@ import { ThemeProvider } from 'styled-components'
 import { App } from '~/client/App'
 import { GlobalStyle } from '~/client/styles/GlobalStyles'
 
-import { firebaseApi } from '~/api/index'
+import { firebaseApi } from '~/api'
 
 function main() {
   const container = document.getElementById('main')


### PR DESCRIPTION
### 🎯 Motivation
Since I was already on a refactoring kick, I noticed that the `fetchData` helper function used in the API logic was better suited in the `~/firebase-app/db` module. Now, instead of importing firebase-related modules and the database in the API module, I'm just importing `fetchData`, which uses the former in its own module. That feels a bit more seamless wrt navigating the codebase.

### ✅ What's Changed
- Change example in `README` to `firebaseApi` import
- Move `fetchData` helper function from `api/index.js` to `firebase-app/db.js`
- Remove unneeded `/index` from imports related to the API
- Capitalize database constant name, remove export