### PR TITLE
feat(ErrorBoundary): create or update GitHub issues on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The frontend starts in [`main.js`]. The root of the React app is in [`App.jsx`].
 #### a word about ~
 
 The webpack config aliases `~` to mean "the root of the app". For example, you
-can `import { firebaseApi } from '~/api'` anywhere in the app, without worrying
-about how many `..`s to have in the relative path.
+can `import { api } from '~/api'` anywhere in the app, without worrying about
+how many `..`s to have in the relative path.
 
 ### Fast Refreshing
 

--- a/api/base.js
+++ b/api/base.js
@@ -1,0 +1,6 @@
+import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react'
+
+export const api = createApi({
+  baseURL: fakeBaseQuery(),
+  endpoints: () => ({}),
+})

--- a/api/base.js
+++ b/api/base.js
@@ -1,6 +1,6 @@
 import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react'
 
 export const api = createApi({
-  baseURL: fakeBaseQuery(),
+  baseQuery: fakeBaseQuery(),
   endpoints: () => ({}),
 })

--- a/api/firebase.js
+++ b/api/firebase.js
@@ -1,0 +1,13 @@
+import { api } from '~/api/base'
+import { fetchData } from '~/firebase-app'
+
+export const firebaseApi = api.injectEndpoints({
+  endpoints: build => ({
+    fetchProjects: build.query({
+      queryFn: () => fetchData('projects'),
+    }),
+    fetchArticles: build.query({
+      queryFn: () => fetchData('articles'),
+    }),
+  }),
+})

--- a/api/github.js
+++ b/api/github.js
@@ -1,0 +1,38 @@
+import { api } from '~/api/base'
+
+const GITHUB_API_URL = 'https://api.github.com'
+const GITHUB_ISSUES_URL = `${GITHUB_API_URL}/repos/DatGreekChick/personal/issues`
+
+const handleGitHub = async (url, method, body = null) => {
+  try {
+    const options = {
+      method,
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${process.env.GITHUB_API_TOKEN}`,
+      },
+      body: body ? JSON.stringify(body) : null,
+    }
+
+    const response = await fetch(url, options)
+    const data = response.json()
+    return { data }
+  } catch (error) {
+    return { error }
+  }
+}
+
+export const gitHubApi = api.injectEndpoints({
+  endpoints: build => ({
+    fetchGitHubIssues: build.query({
+      queryFn: () => handleGitHub(GITHUB_ISSUES_URL, 'GET'),
+    }),
+    updateGitHubIssue: build.mutation({
+      queryFn: ({ id, patch }) =>
+        handleGitHub(`${GITHUB_ISSUES_URL}/${id}`, 'PATCH', patch),
+    }),
+    createGitHubIssue: build.mutation({
+      queryFn: body => handleGitHub(GITHUB_ISSUES_URL, 'POST', body),
+    }),
+  }),
+})

--- a/api/index.js
+++ b/api/index.js
@@ -1,17 +1,12 @@
-import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react'
+import { firebaseApi } from '~/api/firebase'
+import { gitHubApi } from '~/api/github'
 
-import { fetchData } from '~/firebase-app'
-
-export const firebaseApi = createApi({
-  baseQuery: fakeBaseQuery(),
-  endpoints: build => ({
-    fetchProjects: build.query({
-      queryFn: async () => fetchData('projects'),
-    }),
-    fetchArticles: build.query({
-      queryFn: async () => fetchData('articles'),
-    }),
-  }),
-})
+export * from '~/api/base'
 
 export const { useFetchProjectsQuery, useFetchArticlesQuery } = firebaseApi
+
+export const {
+  useFetchGitHubIssuesQuery,
+  useUpdateGitHubIssueMutation,
+  useCreateGitHubIssueMutation,
+} = gitHubApi

--- a/client/components/ErrorFallback.jsx
+++ b/client/components/ErrorFallback.jsx
@@ -2,6 +2,12 @@ import { useEffect, useRef } from 'react'
 import { useLocation } from 'react-router'
 import { styled } from 'styled-components'
 
+import {
+  useCreateGitHubIssueMutation,
+  useFetchGitHubIssuesQuery,
+  useUpdateGitHubIssueMutation,
+} from '~/api'
+
 import { CenterStyledButton } from '~/client/styles/button'
 
 const StyledError = styled.div`
@@ -13,6 +19,42 @@ const StyledError = styled.div`
 export const ErrorFallback = ({ error, resetErrorBoundary }) => {
   const location = useLocation()
   const navigated = useRef(false)
+
+  const { data: issues, isLoading, isError } = useFetchGitHubIssuesQuery()
+  const [createGitHubIssue] = useCreateGitHubIssueMutation()
+  const [updateGitHubIssue] = useUpdateGitHubIssueMutation()
+
+  useEffect(() => {
+    if (isLoading || isError) return
+
+    const formattedStack = `### Error occurred at \`${location.pathname}\` on: ${new Date()}\n\`\`\`console\n${error.stack}\n\`\`\``
+
+    // search for any existing GitHub issues with the error.message title
+    // if issues exist, update all of them, otherwise create a new issue
+    const foundIssues = issues?.filter(issue => issue.title === error.message)
+    if (foundIssues?.length > 0) {
+      foundIssues.forEach(issue =>
+        updateGitHubIssue({
+          id: issue.number,
+          patch: { body: `${issue.body}\n${formattedStack}` },
+        })
+      )
+    } else {
+      createGitHubIssue({
+        title: error.message,
+        body: formattedStack,
+        labels: ['bug'],
+      })
+    }
+  }, [
+    error,
+    issues,
+    location.pathname,
+    isLoading,
+    isError,
+    createGitHubIssue,
+    updateGitHubIssue,
+  ])
 
   useEffect(() => {
     navigated.current ? resetErrorBoundary() : (navigated.current = true)

--- a/main.js
+++ b/main.js
@@ -7,14 +7,14 @@ import { ThemeProvider } from 'styled-components'
 import { App } from '~/client/App'
 import { GlobalStyle } from '~/client/styles/GlobalStyles'
 
-import { firebaseApi } from '~/api'
+import { api } from '~/api'
 
 function main() {
   const container = document.getElementById('main')
   const root = createRoot(container)
 
   root.render(
-    <ApiProvider api={firebaseApi}>
+    <ApiProvider api={api}>
       <GoogleReCaptchaProvider reCaptchaKey={process.env.RECAPTCHA_SITE_KEY}>
         <ThemeProvider theme={{ fontFamily: 'Open Sans, sans-serif' }}>
           <GlobalStyle />


### PR DESCRIPTION
### 🎯 Motivation

I'm hoping / sensing it's rare when issues occur in the app, but if/when they do in production, I want to know about it. The best way I figured I could do that is to track them in GitHub issues. I had thought about using Firebase crashlytics, but they're not available for web-apps. Another option would have been tracking performance using Firebase, but if I'm going to use that, I'd rather do so if the performance of the app is lagging, and it really isn't. In fact, using lazy loading and RTK Query at times makes the app less performant, so adding benchmarking on top of that is a waste of time. A last option would have been to use something like Sentry. This seemed interesting given we use it at work, but it was another tool that needed to be introduced in such a tiny app that it didn't feel warranted to create a personal -- albeit free -- account for such use. Perhaps if issues are frequent, I can shift things around a bit.

Thus, this PR splits out the RTK Query API into two sections:
1. `firebaseApi`
2. `gitHubApi`

Previously, it was only `firebaseApi`, so I needed to create a base API into which to inject endpoints. Then, only in the `ErrorFallback` component does the GitHub API get called. It will search all my repo's issues for the error message as its title, and if it finds any, it will update them with the new stack trace, otherwise it will create a new issue. I'm keeping track of the date issues occur as well as the routes on which they're triggered. 

### ✅ What's Changed
- Update API references in `README` and `main.js`
- Create new API files
  - `api/base.js`, which now only produces the base RTK Query API
  - `api/firebase.js`, which contains the previously existing firebase-specific endpoints and injects them into `api`
  - `api/github.js`, which contains the new GitHub endpoints and injects them into `api`
- Modify `api/index.js` to only export things
- Add update or create GitHub issue logic to `<ErrorFallback />`

### 🧪 Testing
Tested in the browser with a `/fake` route. Successful, non-duplicated results in #253.

<img width="892" alt="Screenshot 2024-12-30 at 14 40 37" src="https://github.com/user-attachments/assets/aae28e39-8dda-430a-a57a-70608bd5e2e5" />
<img width="680" alt="Screenshot 2024-12-30 at 14 40 24" src="https://github.com/user-attachments/assets/e1ad297e-ed1a-433e-8003-7a4595868189" />

RESOLVES #253 