### PR TITLE
refactor: improve mobile sizing of app

### DIFF
--- a/client/components/About.jsx
+++ b/client/components/About.jsx
@@ -7,7 +7,7 @@ const StyledAbout = styled.div`
   display: flex;
   flex-flow: column wrap;
   margin: 0 auto;
-  width: 65%;
+  width: 80%;
 `
 
 export const About = () => (

--- a/client/components/Navbar.jsx
+++ b/client/components/Navbar.jsx
@@ -14,7 +14,7 @@ const Nav = styled.nav`
   justify-content: space-between;
   align-items: center;
   margin: 0 2%;
-  padding: 1rem;
+  padding: 1rem 0;
   vertical-align: text-top;
 `
 

--- a/client/styles/contact.js
+++ b/client/styles/contact.js
@@ -15,7 +15,7 @@ const inputAndTextAreaStyles = css`
   text-align: center;
   width: 100%;
   padding: 1% 0;
-  margin-bottom: 10%;
+  margin: 0 auto 10% auto;
   background: transparent;
   border: transparent;
   border-bottom: thin solid gray;
@@ -31,6 +31,10 @@ export const StyledForm = styled.form`
   flex-flow: column nowrap;
   justify-content: space-between;
   width: 50%;
+
+  @media (max-width: 768px) {
+    width: clamp(70%, 90%, 100%);
+  }
 `
 
 export const Asterisk = styled.span`
@@ -41,7 +45,6 @@ export const Asterisk = styled.span`
 `
 
 export const Input = styled.input`
-  margin-bottom: 20%;
   ${inputAndTextAreaStyles}
 `
 


### PR DESCRIPTION
- Set width of `About` to `Home` width at 80%
- Center form elements better to the page
- Increase width of form elements as the page gets smaller
  - Previously it was static at 50% and rather small on smaller viewports
- Delete unneeded `margin-bottom` of `Input` since `inputAndTextAreaStyles` takes care of it already