### PR TITLE
feat(Header): make header sticky

### DIFF
--- a/client/components/Footer.jsx
+++ b/client/components/Footer.jsx
@@ -31,7 +31,7 @@ const StyledFooter = styled.footer`
   display: flex;
   justify-content: space-between;
   background-color: rgba(0, 0, 0, 1);
-  z-index: 2;
+  z-index: 3;
 `
 
 const Icon = styled.a`

--- a/client/components/Hamburger.jsx
+++ b/client/components/Hamburger.jsx
@@ -4,6 +4,8 @@ import { NavLink } from 'react-router'
 import { Sling } from 'hamburger-react'
 import { styled } from 'styled-components'
 
+const LINKS = ['Home', 'About', 'Work', 'Articles', 'Contact']
+
 const MenuList = styled.ul`
   list-style: none;
   flex-direction: column;
@@ -11,7 +13,7 @@ const MenuList = styled.ul`
   margin: 0;
   padding: 0;
   position: fixed;
-  top: 10%;
+  top: 8.5%;
   z-index: 1;
   left: 0;
   width: 100%;
@@ -43,13 +45,11 @@ const StyledNavLink = styled(NavLink)`
     transform: scaleX(1);
   }
 
-  :active {
-    border-bottom: 1.5px solid #e0bf9f;
+  &.active {
+    border-bottom: 2px solid #e0bf9f;
     color: inherit;
   }
 `
-
-const LINKS = ['Home', 'About', 'Work', 'Articles', 'Contact']
 
 export const Hamburger = () => {
   const [open, setOpen] = useState(false)

--- a/client/components/Navbar.jsx
+++ b/client/components/Navbar.jsx
@@ -6,6 +6,7 @@ import { ErrorFallback } from '~/client/components/ErrorFallback'
 import { Hamburger } from '~/client/components/Hamburger'
 
 const Nav = styled.nav`
+  position: sticky;
   top: 0;
   font-size: 23px;
   font-weight: 800;
@@ -16,6 +17,8 @@ const Nav = styled.nav`
   margin: 0 2%;
   padding: 1rem 0;
   vertical-align: text-top;
+  background-color: rgba(0, 0, 0, 1);
+  z-index: 3;
 `
 
 const Logo = styled.img`
@@ -28,7 +31,7 @@ const Logo = styled.img`
 export const Navbar = () => (
   <>
     <Nav role='navigation'>
-      <NavLink to='/'>
+      <NavLink to='/' style={{ zIndex: 4, paddingLeft: '5px' }}>
         <Logo src='/assets/img/CreamLogo.png' alt='eak-logo-cream' />
       </NavLink>
       <Hamburger />

--- a/client/styles/GlobalStyles.js
+++ b/client/styles/GlobalStyles.js
@@ -3,7 +3,6 @@ import { createGlobalStyle } from 'styled-components'
 export const GlobalStyle = createGlobalStyle`
   body {
     background-color: rgba(0, 0, 0, 1);
-    padding-bottom: 5%;
   }
   
   body,


### PR DESCRIPTION
### 🎯 Motivation

While I was browsing the site on mobile I realized it would be nicer / more app-like to have the header be sticky, just like the footer is. There were some minor adjustments I needed to make to other styles in order to ensure the hamburger menu items list continues to render with the navbar and footer rendering with it.

### ✅ What's Changed
- Make navbar `position: sticky`
- Increase `z-index` of `StyledFooter`, `Nav` and logo `NavLink`
- Delete `padding-bottom` for site `body`
  - When I was attempting using `position: sticky` for the footer as well, this was getting added when scrolling all the way to the end. I believe I added this because when scrolling I wanted a bit of space between the end of the content and the page, but I had forgotten about it entirely, and it wasn't really offering much benefit.
  - I decided to keep the `position` as `fixed` for the footer since I wanted to use `sticky` only when I thought the footer wasn't rendering at all at smaller viewports (turns out I needed to adjust the viewing percentage in chrome!).
- Decrease `top` to 8.5% for `MenuList`
  - With a sticky header, the hamburger menu when open was rendering with content in the back. This helps with almost all devices available on Chrome dev tools, so it didn't seem worth doing more as the rest of the experience is the same.
- Set a background color to the navbar

#### 🚗 Drive by changes _beep, beep!_
- Fix: Active links on the hamburger menu were not actually working, but now they do with `&.active` instead of `:active` or `&:active` (`NavLink` sets the `.active` property)
- Refactor: Move `LINKS` constant to the top of the file after imports in `client/components/Hamburger.jsx`
- Refactor: Increase `padding-left` for logo so it matches the hamburger menu

### 🧪 Testing
Tested on the browser using Chrome dev tools with every single device in the default/supplied list as well as responsive.