### PR TITLE
refactor: delete empty env.config.js, unnecessary .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,0 @@
-node_modules


### PR DESCRIPTION
### 🎯 Motivation

Clean things up a smidge that don't need to be there anymore!

### ✅ What's Changed

- Delete empty `env.config.js` file
- Delete `.prettierignore`

### 📝 Note

Prettier ignores `node_modules` by default, and since this was the only directory/file in `.prettierignore`, there's no sense keeping it around. Prettify all the files! 😈 

### 🔗 Links
- https://prettier.io/docs/en/cli.html#--with-node-modules