### PR TITLE
fix(UsesSection): upon click, reset icon hover state

### DIFF
--- a/client/components/uses/UsesSection.jsx
+++ b/client/components/uses/UsesSection.jsx
@@ -83,15 +83,11 @@ export const UsesSection = ({ section }) => {
       <h2>
         <StyledRouterLink to={hash} onClick={handleClick(sectionTitle)}>
           {section.title}
-          {!visibility ? (
-            <StyledFontAwesomeIcon
-              icon={faCopy}
-              className='copy-icon'
-              visibility={visibility}
-            />
-          ) : (
-            <StyledFontAwesomeIcon icon={faCheck} visibility={visibility} />
-          )}
+          <StyledFontAwesomeIcon
+            icon={visibility === 'visible' ? faCheck : faCopy}
+            className='copy-icon'
+            visibility={visibility}
+          />
         </StyledRouterLink>
       </h2>
       {section.description && (

--- a/client/styles/uses.js
+++ b/client/styles/uses.js
@@ -35,7 +35,7 @@ export const StyledFontAwesomeIcon = styled(FontAwesomeIcon)`
     props.visibility === 'visible' ? '#ace1af' : 'ghostwhite'};
   margin-left: 8px;
   cursor: pointer;
-  font-size: 1.2rem;
+  font-size: 1rem;
   opacity: 0;
   visibility: ${props => props.visiblity};
   transition:


### PR DESCRIPTION
### 🎯 Motivation
After deploying #272 I noticed a bug: after clicking a section, the state was not correctly being updated. What would happen is no icon would appear. There were also multiple hashes being added. Now, the code is cleaner as well as correct: after clicking, hovering on the same section will show you the copy icon. I clicked a bunch of times to ensure that the hashes were working as expected as well. Lastly, I made the icon a bit smaller since it felt rather large at `1.2rem`.

### ✅ What's Changed
- Reduce `font-size` from `1.2rem` to `1rem`
- Render the `FontAwesomeIcon` based on the visibility state using `icon` instead of two different `FontAwesomeIcon`s