### PR TITLE
refactor: simplify visibility state

### DIFF
--- a/client/components/uses/UsesSection.jsx
+++ b/client/components/uses/UsesSection.jsx
@@ -47,34 +47,23 @@ const renderItems = items => {
 }
 
 export const UsesSection = ({ section }) => {
-  const [clicked, setClicked] = useState({})
+  const [visibility, setVisibility] = useState('hidden')
   const navigate = useNavigate()
 
   const sectionTitle = section.title.toLowerCase().split(' ').join('-')
-  const visibility = clicked[sectionTitle]
   const hash = `#${sectionTitle}`
 
   const handleClick = sectionTitle => evt => {
     evt.preventDefault()
 
-    // copy link text to user's clipboard and set clicked state to render check
+    // copy link text to user's clipboard
     navigator.clipboard.writeText(`${location.href}${hash}`).then(() => {
-      setClicked(prevState => ({
-        ...prevState,
-        [sectionTitle]: 'visible',
-      }))
+      setVisibility('visible')
 
-      // update the URL in the browser and scroll to section top
+      // update the URL in the browser, scroll to section top, reset visibility
       navigate(hash)
       scrollToSection(sectionTitle)
-
-      // reset the clicked state so that the checkmark disappears
-      setTimeout(() => {
-        setClicked(prevState => ({
-          ...prevState,
-          [sectionTitle]: 'hidden',
-        }))
-      }, 1000)
+      setTimeout(() => setVisibility('hidden'), 1000)
     })
   }
 


### PR DESCRIPTION
### 🎯 Motivation
In looking at the recent changes, the `UsesSection` is going to render for each section, so visibility can be at the component-level instead of tracked amongst all instances. Thus, this commit uses `visibility` as state directly and does away with `clicked` hash state. The code works as before, albeit better!

### ✅ What's Changed
- Change `clicked` state to `visibility` state
- Modify relevant state type from Object to String
- Clean up function calls and comments