### PR TITLE
perf: load Google Fonts asynchronously to unblock FCP

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -42,7 +42,7 @@
     <link rel="shortcut icon" href="/assets/favicon.ico" type="image/x-icon"/>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;800&display=swap">
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;800&display=swap" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;800&display=swap" media="print" onload="this.media='all'">
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;800&display=swap"></noscript>
     <link rel="manifest" href="manifest.json">

--- a/public/index.html
+++ b/public/index.html
@@ -40,7 +40,11 @@
     <title>Eleni Konior: Engineer - Dreamer - Greek</title>
 
     <link rel="shortcut icon" href="/assets/favicon.ico" type="image/x-icon"/>
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,800" rel="stylesheet" media="all">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;800&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;800&display=swap" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;800&display=swap"></noscript>
     <link rel="manifest" href="manifest.json">
   </head>
   <body>


### PR DESCRIPTION
## Summary
- Replaces render-blocking `<link rel="stylesheet" media="all">` with the async `media="print"` + `onload` pattern
- Adds `preconnect` hints for both `fonts.googleapis.com` and `fonts.gstatic.com`
- Adds `preload as="style"` for the font stylesheet
- Upgrades URL to `css2` format with `display=swap` for immediate fallback text render
- Includes `<noscript>` fallback for users with JS disabled

## Why
Google Fonts loaded as a render-blocking stylesheet was stalling First Contentful Paint (currently 3.1s). This change unblocks FCP without changing visual behavior — Open Sans still loads, just asynchronously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)