### PR TITLE
fix: bump service worker cache to v3 and update font URL

### DIFF
--- a/public/serviceWorker.js
+++ b/public/serviceWorker.js
@@ -1,10 +1,10 @@
-const CACHE_NAME = 'v2'
+const CACHE_NAME = 'v3'
 const urlsToCache = [
   '/',
   '/assets/img/CreamLogo.png',
   '/main.js',
   '/index.html',
-  'https://fonts.googleapis.com/css?family=Open+Sans:300,800',
+  'https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;800&display=swap',
 ]
 
 // https://stackoverflow.com/a/70863551


### PR DESCRIPTION
## Summary
- Bumps `CACHE_NAME` from `v2` to `v3` so returning visitors' stale caches are invalidated on next visit
- Replaces the old blocking font URL with the new async-compatible `css2` URL in `urlsToCache`

## Why
The font loading change (PR #414) updated `index.html` to use the new async font URL (`css2?family=Open+Sans:wght@300;800&display=swap`) but did not update the service worker. As a result:
- The SW pre-fetches the old font URL on every fresh install (wasted request, confirmed in Lighthouse trace)
- Repeat visitors whose SW is still on cache `v2` are served the old cached `index.html` — which still has the render-blocking font tag — completely undoing PR #414's FCP improvement for all returning users

Generated with Claude Code