### PR TITLE
perf: warm up Firebase on idle after home page renders

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,3 +18,8 @@ function main() {
 }
 
 main()
+
+// Warm up Firebase during idle time so it's ready before the user navigates
+// to a data route, without blocking the home page critical path
+const idle = globalThis.requestIdleCallback ?? (fn => setTimeout(fn, 0))
+idle(() => import('./firebase-app'))


### PR DESCRIPTION
## Summary

Firebase lazy-loading (#429) improved home page TTI significantly but introduced a noticeable delay on the first navigation to /work, /articles, or /uses — Firebase initializes from scratch at that point instead of at app boot.

This triggers the Firebase dynamic import via requestIdleCallback (setTimeout fallback) once the home page is painted and the main thread goes idle. Firebase is ready before the user navigates, without touching the home page critical path.

## Test plan

- [ ] Confirm home page Lighthouse numbers unchanged
- [x] Navigate to /work, /articles, /uses — first load should feel as fast as before #429

Generated with [Claude Code](https://claude.com/claude-code)