### PR TITLE
fix: restore default line-height on UsesSection call-to-action text

### DIFF
--- a/client/components/uses/Uses.module.css
+++ b/client/components/uses/Uses.module.css
@@ -65,7 +65,6 @@
   color: ghostwhite;
   font-style: italic;
   font-size: 15px;
-  line-height: 1;
 }
 
 .callToActionAnchor {
@@ -73,7 +72,6 @@
   text-decoration: none;
   font-weight: 600;
   font-size: 15px;
-  line-height: 1;
   padding-bottom: 10px;
 }
 


### PR DESCRIPTION
## Summary

- Removes `line-height: 1` from `.callToActionText` and `.callToActionAnchor` in `Uses.module.css`
- The cramped value caused insufficient spacing between lines on mobile when CTA text wrapped

## Test plan

- [ ] View the Uses page on a mobile viewport and confirm the CTA under "Podcasts" has natural line spacing
- [ ] Confirm other sections with descriptions are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)