### PR TITLE
fix: correct line-height and hamburger overlay on mobile/large screens

### DIFF
--- a/client/components/navigation/Hamburger.module.css
+++ b/client/components/navigation/Hamburger.module.css
@@ -5,7 +5,7 @@
   margin: 0;
   padding: 0;
   position: fixed;
-  top: 8.5%;
+  top: 4rem;
   z-index: 1;
   left: 0;
   width: 100%;

--- a/client/components/uses/Uses.module.css
+++ b/client/components/uses/Uses.module.css
@@ -65,7 +65,6 @@
   color: ghostwhite;
   font-style: italic;
   font-size: 15px;
-  line-height: 1;
 }
 
 .callToActionAnchor {
@@ -73,7 +72,6 @@
   text-decoration: none;
   font-weight: 600;
   font-size: 15px;
-  line-height: 1;
   padding-bottom: 10px;
 }
 


### PR DESCRIPTION
## Summary

- Removes `line-height: 1` from `.callToActionText` and `.callToActionAnchor` in `Uses.module.css` — the tight value caused cramped spacing when CTA text wrapped on mobile
- Changes `.menuList` `top` from `8.5%` to `4rem` in `Hamburger.module.css` — the percentage-based value created a gap on large/tall screens where page content (e.g. the resume button on `/work`) was visible behind the open menu overlay

## Test plan

- [x] View the Uses page on mobile and confirm the CTA under "Podcasts" has natural line spacing
- [ ] Open the hamburger menu on a large screen and confirm the overlay covers content flush to the navbar (no resume button peeking through at the top on `/work`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)