### PR TITLE
fix(ci): add Node 25 for semantic-release v25, sync bun.lock

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 25
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest

--- a/bun.lock
+++ b/bun.lock
@@ -2689,6 +2689,8 @@
 
     "semantic-release/read-package-up": ["read-package-up@12.0.0", "", { "dependencies": { "find-up-simple": "^1.0.1", "read-pkg": "^10.0.0", "type-fest": "^5.2.0" } }, "sha512-Q5hMVBYur/eQNWDdbF4/Wqqr9Bjvtrw2kjGxxBbKLbx8bVCL8gcArjTy8zDUuLGQicftpMuU0riQNcAsbtOVsw=="],
 
+    "semantic-release/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "semantic-release/yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
 
     "semver-diff/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
-      ["@semantic-release/npm", { "npmPublish": false }],
+      ["@semantic-release/npm", {
+        "npmPublish": false
+      }],
       ["@semantic-release/git", {
         "assets": ["package.json"],
         "message": "chore(release): ${nextRelease.version} [skip ci]"


### PR DESCRIPTION
#### 🎯 Motivation

After #434 merged, the release workflow failed because semantic-release v25 requires Node >=22 but GitHub Actions runners default to Node 20. Even with bun as the package manager, semantic-release runs on the system Node.

#### ✅ What's Changed

- Add setup-node@v4 with Node 25 before setup-bun in release workflow
- Add missing semver entry under semantic-release in bun.lock
- Expand inline @semantic-release/npm config to multi-line for consistency

#### 🧪 Testing

CI failure confirmed via gh run view — Node v20.20.2 rejected by semantic-release v25

#### 🔗 Links

- [Failed run]

[failed run]: https://github.com/DatGreekChick/personal/actions/runs/24616957314