### PR TITLE
fix(app): add explicit repositoryUrl for semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     }
   },
   "release": {
+    "repositoryUrl": "https://github.com/DatGreekChick/personal.git",
     "branches": ["main"],
     "plugins": [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
#### 🎯 Motivation

semantic-release fails to resolve the git remote because the `repository` field in `package.json` is `"github.com/DatGreekChick/personal"` — no protocol — so URL parsing produces `null` as the host.

#### ✅ What's Changed

- Add `repositoryUrl` to the release config pointing to the full HTTPS URL

#### 🧪 Testing

CI failure: `git ls-remote --heads 'https://x-access-token:[secure]@null/github.com/DatGreekChick/personal'` — host was null due to unparseable repository field

#### 🔗 Links

- [Failed run]

[failed run]: https://github.com/DatGreekChick/personal/actions/runs/24616957314